### PR TITLE
Pulp Consumer registration

### DIFF
--- a/puppet/pulp/README.md
+++ b/puppet/pulp/README.md
@@ -303,6 +303,12 @@ This setting corresponds to the [server] `host` field.
 ####`pulp_port`
 This setting corresponds to the [server] `port` field.
 
+####`pulp_login`
+This setting corresponds to the login user for the pulp server
+
+####`pulp_password`
+This setting corresponds to the login password for the pulp server
+
 ####`pulp_api_prefix`
 This setting corresponds to the [server] `api_prefix` field.
 
@@ -316,6 +322,12 @@ is `True`.
 ####`ca_path`
 This setting corresponds to the [server] `ca_path` field. The default
 is `/etc/pki/tls/certs/`
+
+####`id`
+This setting corresponds to the id of the consumer. The default is its hostname.
+
+####`display_name`
+This setting corresponds to the name of the consumer. The default is its fqdn.
 
 ####`consumer_rsa_key`
 This setting corresponds to the [authentication] `rsa_key` field.

--- a/puppet/pulp/manifests/consumer.pp
+++ b/puppet/pulp/manifests/consumer.pp
@@ -6,10 +6,14 @@ class pulp::consumer (
     $pulp_server_ca_cert = undef,
     $pulp_server        = $::pulp_server,
     $pulp_port          = 443,
+    $pulp_login         = undef,
+    $pulp_password      = undef,
     $pulp_api_prefix    = '/pulp/api',
     $pulp_rsa_pub       = '/etc/pki/pulp/consumer/server/rsa_pub.key',
     $verify_ssl         = 'True',
     $ca_path            = '/etc/pki/tls/certs/',
+    $id                 = $::hostname,
+    $display_name       = $::fqdn,
 
     # Authentication
     $consumer_rsa_key = '/etc/pki/pulp/consumer/rsa.key',
@@ -57,6 +61,7 @@ class pulp::consumer (
     class { 'pulp::consumer::install': } ->
     class { 'pulp::consumer::config': } ->
     class { 'pulp::consumer::service': } ->
+    class { 'pulp::consumer::register': } ->
     anchor { 'pulp::consumer::end': }
 }
 

--- a/puppet/pulp/manifests/consumer/register.pp
+++ b/puppet/pulp/manifests/consumer/register.pp
@@ -1,0 +1,12 @@
+# This is is a private class that should not be called directly.
+# Use pulp::consumer instead.
+
+class pulp::consumer::register {
+      
+  if( $pulp::consumer::pulp_login != undef ) and ( $pulp::consumer::pulp_password != undef ) {
+    exec { 'pulp-consumer-register':
+      command => "/usr/bin/pulp-consumer -u ${pulp::consumer::pulp_login} -p ${pulp::consumer::pulp_password} register --consumer-id ${pulp::consumer::id} --display-name ${pulp::consumer::display_name}",
+      unless  => '/usr/bin/pulp-consumer status | /bin/grep "This consumer is registered to the server"',
+    }
+  }
+}


### PR DESCRIPTION
Adding a step to the consumer configuration to allow the consumer to register himself after a successful installation

Fixes #21 
