### PR TITLE
Remove http service definition

### DIFF
--- a/puppet/pulp/README.md
+++ b/puppet/pulp/README.md
@@ -29,7 +29,7 @@ and a Qpid module of your choice to set up these dependencies as necessary.
  * Pulp yum repository.
  * Pulp packages.
  * Pulp configuration files.
- * The httpd, pulp_workers, pulp_celerybeat, and pulp_resource_manager services
+ * The pulp_workers, pulp_celerybeat and pulp_resource_manager services
 
 ###Beginning with Pulp
 

--- a/puppet/pulp/manifests/node/service.pp
+++ b/puppet/pulp/manifests/node/service.pp
@@ -2,11 +2,6 @@
 
 class pulp::node::service {
 
-    service { 'httpd':
-        ensure => 'running',
-        enable => true
-    }
-
     service { 'goferd':
         ensure => 'running',
         enable => true

--- a/puppet/pulp/manifests/server/service.pp
+++ b/puppet/pulp/manifests/server/service.pp
@@ -2,10 +2,6 @@
 
 class pulp::server::service {
 
-    service { 'httpd':
-        ensure => 'running',
-        enable => true
-    }
     service { 'pulp_workers':
         ensure => 'running',
         enable => true


### PR DESCRIPTION
Remove http service definitions from node and server manifests. It only confuses and brakes stuff while trying to install apache using other modules.
