### PR TITLE
Use file as locking to avoid repeated pulp db migration

### DIFF
--- a/puppet/pulp/manifests/server/config.pp
+++ b/puppet/pulp/manifests/server/config.pp
@@ -8,8 +8,9 @@ class pulp::server::config {
         group   => 'apache',
         mode    => '0640'
     } -> exec { 'Migrate DB':
-        command => '/usr/bin/pulp-manage-db',
-        user    => 'apache'
+        command => '/usr/bin/pulp-manage-db && touch /var/lib/pulp/.puppet-pulp-manage-db',
+        user    => 'apache',
+        creates => '/var/lib/pulp/.puppet-pulp-manage-db'
     }
 
     # Configure Apache


### PR DESCRIPTION
No need to run pulp-manage-db  every execution
