### PR TITLE
Fix incorrect resource ordering during pulp server installation

### DIFF
--- a/puppet/pulp/manifests/server/install.pp
+++ b/puppet/pulp/manifests/server/install.pp
@@ -15,4 +15,6 @@ class pulp::server::install {
             ensure => 'installed'
         }
     }
+
+    Exec['yum install pulp-server'] -> Package['pulp-nodes-parent']
 }


### PR DESCRIPTION
In case when pulp-nodes-parent is installed first, pulp server group installation becomes false positive.
