### PR TITLE
change automated test checkout branch from pulp-2.4 to pulp-2.5

### DIFF
--- a/ci/deploy/config/jenkins/el7-config.yml
+++ b/ci/deploy/config/jenkins/el7-config.yml
@@ -32,4 +32,4 @@ pulp_tester:
     os_name: Fedora
     os_version: 20
     tests_destination: test/el7.xml
-    test_suite_branch: pulp-2.4
+    test_suite_branch: pulp-2.5

--- a/ci/deploy/config/jenkins/fc20-config.yml
+++ b/ci/deploy/config/jenkins/fc20-config.yml
@@ -32,4 +32,4 @@ pulp_tester:
     os_name: Fedora
     os_version: 20
     tests_destination: test/fc20.xml
-    test_suite_branch: pulp-2.4
+    test_suite_branch: pulp-2.5


### PR DESCRIPTION
This is a temporary fix to set the branch to 2.5. Ideally it would be read from
the build params when the job runs.