### PR TITLE
remove qpid persistent store

### DIFF
--- a/dockerfiles/centos/qpid/Dockerfile
+++ b/dockerfiles/centos/qpid/Dockerfile
@@ -4,12 +4,8 @@ MAINTAINER Pulp Team <pulp-list@redhat.com>
 RUN yum install -y epel-release && yum clean all
 
 RUN  yum update -y && \
-     yum install -y qpid-cpp-server qpid-cpp-server-store python-qpid-qmf python-qpid \
+     yum install -y qpid-cpp-server python-qpid-qmf python-qpid \
      yum clean all
-
-ADD . /.qpidd
-
-WORKDIR /.qpidd
 
 EXPOSE 5672
 


### PR DESCRIPTION
The removed package failed to work with this image when run on an Ubuntu
host. Since this is just a demo deployment of pulp, it's sufficient to
live without the persistent store.

I also cleaned up an ADD and WORKDIR statement that I don't think were
adding any value.