### PR TITLE
141 - Validate and keep up-to-date redmine and bugzilla data

### DIFF
--- a/ci/jobs/ci-redmine-bugzilla.yaml
+++ b/ci/jobs/ci-redmine-bugzilla.yaml
@@ -1,0 +1,62 @@
+# This Jenkins job runs a script which performs automation related to Redmine
+# and Bugzilla. See https://github.com/pulp/pulp_packaging/ci/redmine_bugzilla.py
+
+- job-template:
+    name: 'redmine-bugzilla-automation'
+    defaults: ci-workflow-runtest
+    node: 'f21-np'
+    scm:
+        - git:
+            url: 'https://github.com/pulp/pulp_packaging.git'
+            branches:
+                - origin/master
+            basedir: pulp_packaging
+            skip-tag: true
+            wipe-workspace: false
+    triggers:
+        - timed: "0,30 * * * *"
+    wrappers:
+        - credentials-binding:
+            - file:
+                credential-id: 099bc04b-80b6-4cd6-ad1d-11908641f539
+                variable: REDMINE_BUGZILLA_CONF
+        - timeout:
+            # Timeout in minutes
+            timeout: 30
+            timeout-var: 'BUILD_TIMEOUT'
+            fail: true
+    builders:
+        - shell: |
+            #!/bin/bash
+            git config --global user.email "pulp-infra@redhat.com"
+            git config --global user.name "pulpbot"
+            set -x
+            env
+
+            cd $WORKSPACE/
+
+            sudo pip install --upgrade git+https://github.com/bmbouter/python-bugzilla.git@expand-external-tracker-support
+            sudo pip install python-redmine
+
+            # Here due to InsecurePlatformWarning
+            # https://urllib3.readthedocs.org/en/latest/security.html#insecureplatformwarning
+            sudo pip install pyopenssl ndg-httpsclient pyasn1
+
+            python pulp_packaging/ci/redmine_bugzilla.py
+
+    publishers:
+      # Take the node offline so that another build doesn't pile on
+      - groovy-postbuild: "manager.build.getBuiltOn().toComputer().setTemporarilyOffline(true)"
+      - email-ext:
+          recipients: 'bbouters@redhat.com,mhrivnak@redhat.com'
+          reply-to: $DEFAULT_REPLYTO
+          subject: 'Upstream/Downstream Linking Issues'
+          body: $DEFAULT_CONTENT
+          failure: false
+          first-failure: true
+
+
+- project:
+    name: redmine-bugzilla-automation
+    jobs:
+     - 'redmine-bugzilla-automation'

--- a/ci/redmine_bugzilla.py
+++ b/ci/redmine_bugzilla.py
@@ -1,0 +1,172 @@
+"""
+This module does a few things:
+
+0) Verify that all Bugzilla bugs which point to a Redmine issues also have
+Redmine issues pointing back to Bugzilla bugs. This script print a report of
+changes made and any linking issues are found. If any link issues are
+detected, a RuntimeError is raised so the caller will know an issue occurred.
+
+1) For all Redmine issues that track Bugzilla bugs, ensure that the
+Bugzilla external tracker description, status, and priority all mirror the
+Redmine issue state. Also put a comment on the Bugzilla bug when changes are
+made.
+
+Requirements:
+The Redmine and Bugzilla credentials are expected from to be read from a
+file in ini format. See the example below. The location of this file is set
+by the REDMINE_BUGZILLA_CONF environment variable.
+
+<SNIP>
+[bugzilla]
+username = XXXX
+password = XXXX
+
+[redmine]
+key = XXXX
+</SNIP>
+"""
+
+
+import ConfigParser
+import os
+
+from bugzilla.rhbugzilla import RHBugzilla
+from redmine import Redmine
+import urllib3.contrib.pyopenssl
+
+# Here due to InsecurePlatformWarning
+# https://urllib3.readthedocs.org/en/latest/security.html#insecureplatformwarning
+urllib3.contrib.pyopenssl.inject_into_urllib3()
+
+
+BUGZILLA_URL = 'https://bugzilla.redhat.com'
+REDMINE_URL = 'https://pulp.plan.io'
+
+
+def get_bugzilla_connection(user, password):
+    """
+    Return the Bugzilla connection.
+
+    :param user: The username to connect with
+    :type user: basestring
+    :param password: The password to connect with
+    :type password: basestring
+
+    :return: An instantiated Bugzilla connection object.
+    """
+    return RHBugzilla(url='%s/xmlrpc.cgi' % BUGZILLA_URL, user=user, password=password)
+
+
+def get_redmine_connection(key):
+    """
+    Return the Redmine connection.
+
+    :param key: The api key to connect with
+    :type key: basestring
+
+    :return: An instantiated Redmine connection object.
+    """
+    return Redmine(REDMINE_URL, key=key)
+
+
+def main():
+    config = ConfigParser.ConfigParser()
+    config.read(os.environ['REDMINE_BUGZILLA_CONF'])
+
+    username = config.get('bugzilla', 'username')
+    password = config.get('bugzilla', 'password')
+    key = config.get('redmine', 'key')
+
+    redmine = get_redmine_connection(key)
+    BZ = get_bugzilla_connection(username, password)
+
+    redmine_issues = [issue for issue in redmine.issue.filter(query_id=24)]
+
+    non_closed_bug_with_ext_tracker = BUGZILLA_URL + '/buglist.cgi?bug_status=NEW&' \
+        'bug_status=ASSIGNED&bug_status=POST&bug_status=MODIFIED&bug_status=ON_DEV&' \
+        'bug_status=ON_QA&bug_status=VERIFIED&bug_status=RELEASE_PENDING&' \
+        'columnlist=priority%2Cbug_severity%2Cbug_status%2Cshort_desc%2Cchangeddate%2C' \
+        'component%2Ctarget_release%2Cassigned_to%2Creporter&f1=external_bugzilla.url&' \
+        'list_id=3309842&o1=substring&query_format=advanced&v1=pulp.plan.io'
+    bugzilla_bugs = BZ.query(RHBugzilla.url_to_query(non_closed_bug_with_ext_tracker))
+
+    links_issues_record = ''
+    ext_bug_record = ''
+
+    for issue in redmine_issues:
+        for custom_field in issue.custom_fields.resources:
+            if custom_field['name'] == 'Bugzilla':
+                if custom_field['value'] == '':
+                    continue
+                bug = BZ.getbug(int(custom_field['value']))
+                links_back = False
+                for external_bug in bug.external_bugs:
+                    if external_bug['type']['description'] == 'Pulp Redmine' and \
+                                    external_bug['ext_bz_bug_id'] == str(issue.id):
+                        ext_params = {}
+                        if external_bug['ext_description'] != issue.subject:
+                            ext_params['ext_description'] = issue.subject
+                        if external_bug['ext_status'] != issue.status.name:
+                            ext_params['ext_status'] = issue.status.name
+                        if external_bug['ext_priority'] != issue.priority.name:
+                            ext_params['ext_priority'] = issue.priority.name
+                        if len(ext_params.keys()) > 0:
+                            ext_bug_record += 'Bugzilla bug %s updated from upstream bug %s with ' \
+                                              '%s\n' % (bug.id, issue.id, ext_params)
+                            ext_params['ids'] = external_bug['id']
+                            BZ.update_external_tracker(**ext_params)
+                            if 'ext_status' in ext_params:
+                                bug.addcomment(
+                                    'The Pulp upstream bug status is at %s. Updating the external '
+                                    'tracker on this bug.' % issue.status.name)
+                            if 'ext_priority' in ext_params:
+                                bug.addcomment(
+                                    'The Pulp upstream bug priority is at %s. Updating the '
+                                    'external tracker on this bug.' % issue.priority.name)
+
+                        # Remove the bug list gotten via search so we don't examine it again when
+                        #  bugzilla_bugs are iterated through
+                        bug_in_search_index_to_remove = None
+                        for i, bug_in_search in enumerate(bugzilla_bugs):
+                            if bug_in_search.id == bug.id:
+                                bug_in_search_index_to_remove = i
+                                break
+                        if bug_in_search_index_to_remove is not None:
+                            bugzilla_bugs.pop(bug_in_search_index_to_remove)
+
+                        links_back = True
+                if not links_back:
+                    links_issues_record += 'Redmine #%s -> Bugzilla %s, but Bugzilla %s does not ' \
+                                           'link back\n' % (issue.id, bug.id, bug.id)
+
+    for bug in bugzilla_bugs:
+        for external_bug in bug.external_bugs:
+                if external_bug['type']['description'] == 'Pulp Redmine':
+                    issue_id = external_bug['ext_bz_bug_id']
+                    issue = redmine.issue.get(issue_id)
+                    links_back = False
+                    for custom_field in issue.custom_fields.resources:
+                        if custom_field['name'] == 'Bugzilla':
+                            if custom_field['value'] == '':
+                                continue
+                            if int(custom_field['value']) == bug.id:
+                                links_back = True
+                    if not links_back:
+                        links_issues_record += 'Bugzilla #%s -> Redmine %s, but Redmine %s does ' \
+                                               'not link back\n' % (bug.id, issue.id, issue.id)
+
+    if ext_bug_record != '':
+        print '\nBugzilla Updates From Upstream'
+        print '------------------------------'
+        print ext_bug_record
+
+    if links_issues_record != '':
+        print '\nLink Issues'
+        print '-----------'
+        print links_issues_record
+        # Raise an exception so the job fails and Jenkins will send e-mail
+        raise RuntimeError('Upstream/Downstream Link issues are detected')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Adds a Jenkins job definition which periodically runs a python
script. The Python script validates that upstream and downstream
bugs have bi-directional relationships. The script also replicates
upstream issue status to the downstream external tracker info. A
report of issues identified and changes made are sent to a list
of admins.