### PR TITLE
Using the pulp-server-qpid group instead of just pulp-server

### DIFF
--- a/dockerfiles/centos/base/Dockerfile
+++ b/dockerfiles/centos/base/Dockerfile
@@ -7,7 +7,7 @@ RUN yum install -y epel-release && yum clean all
 
 RUN yum update -y && yum install -y python-qpid python-qpid-qmf pulp-docker-plugins \
     pulp-python-plugins findutils nmap-ncat && \
-    yum groupinstall -y pulp-server && \
+    yum groupinstall -y pulp-server-qpid && \
     yum clean all
 
 # A volume will be mounted here, clobbering the base structure. We keep a copy


### PR DESCRIPTION
A change between 2.6.0 and 2.6.1 meant that python-gofer-qpid was no longer
getting installed while building the docker images. This Dockerfile should
have used the -qpid group to begin with, so it's not anyone else's fault.