### PR TITLE
Fixes error when Bugzilla field is empty in bugzilla automation

### DIFF
--- a/ci/redmine_bugzilla.py
+++ b/ci/redmine_bugzilla.py
@@ -174,6 +174,9 @@ def main():
                             except KeyError:
                                 # If value isn't present this field is not linking back so continue
                                 continue
+                            except ValueError:
+                                # If value is present but empty this field is not linking back
+                                continue
                     if not links_back:
                         links_issues_record += 'Bugzilla #%s -> Redmine %s, but Redmine %s does ' \
                                                'not link back\n' % (bug.id, issue.id, issue.id)


### PR DESCRIPTION
There isn't a bug on this issue, but without this the automation
was raising the following exception:

```
Traceback (most recent call last):
  File "pulp_packaging/ci/redmine_bugzilla.py", line 195, in <module>
    main()
  File "pulp_packaging/ci/redmine_bugzilla.py", line 172, in main
    if int(custom_field['value']) == bug.id:
```