### PR TITLE
Issue creating Dockerfile repository

### DIFF
--- a/dockerfiles/registry-admin.py
+++ b/dockerfiles/registry-admin.py
@@ -117,7 +117,7 @@ class Pulp(object):
             if self.args.git_url:
                 git_str = "--note git-url=%s" % self.args.git_url
             cmd.append("docker repo create --repo-registry-id %s --repo-id %s %s --redirect-url http://pulpapi/pulp/docker/%s/" %
-                        (self.args.repo, self.repo_name(self.args.repo), git_str), self.repo_name(self.args.repo))
+                        (self.args.repo, self.repo_name(self.args.repo), git_str, self.repo_name(self.args.repo)))
         elif self.args.mode == "sync":
             cmd.append("docker repo create --repo-registry-id %s --repo-id %s --feed %s --upstream-name %s --validate True" %
                         (self.args.repo, self.repo_name(self.args.repo), self.args.sync_url, self.args.repo))


### PR DESCRIPTION
I ran into an issue when trying to create a new Dockerfile repo today.  Ran `./registry-admin.py create spotify/kafka --git-url https://github.com/spotify/docker-kafka/tree/master/kafka -b master` and got the following error: 
```
Traceback (most recent call last):
  File "./registry-admin.py", line 274, in <module>
    main()
  File "./registry-admin.py", line 271, in main
    p.execute()
  File "./registry-admin.py", line 162, in execute
    for cmd in self.parsed_args():
  File "./registry-admin.py", line 120, in parsed_args
    (self.args.repo, self.repo_name(self.args.repo), git_str), self.repo_name(self.args.repo))
TypeError: not enough arguments for format string
```

I figured it was due to misplaced parentheses and tried the fix locally and seemed to resolve the issue.