### PR TITLE
Add ansible playbook for Pulp Smash automation

### DIFF
--- a/ci/ansible/ansible.cfg
+++ b/ci/ansible/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+remote_user=root

--- a/ci/ansible/pulp_smash_automation.yaml
+++ b/ci/ansible/pulp_smash_automation.yaml
@@ -1,0 +1,8 @@
+---
+
+- hosts: all
+  roles:
+    - role: pulp
+      pulp_install_server: true
+    - pulp-smash
+  sudo: true

--- a/ci/ansible/roles/pulp-smash/defaults/main.yml
+++ b/ci/ansible/roles/pulp-smash/defaults/main.yml
@@ -1,0 +1,11 @@
+# Pulp Server base URL
+pulp_smash_baseurl: "https://localhost"
+
+# Pulp Server username
+pulp_smash_username: "admin"
+
+# Pulp Server password
+pulp_smash_password: "admin"
+
+# If SSL certificate should be verified
+pulp_smash_verify: "false"

--- a/ci/ansible/roles/pulp-smash/tasks/main.yaml
+++ b/ci/ansible/roles/pulp-smash/tasks/main.yaml
@@ -1,0 +1,30 @@
+---
+
+- name: Remove previous Pulp Smash repository
+  shell: rm -rf pulp-smash
+
+- name: Clone Pulp Smash repository
+  git: repo=https://github.com/PulpQE/pulp-smash.git depth=1 dest=pulp-smash
+
+- name: Install required OS packages
+  action: "{{ ansible_pkg_mgr }} name={{ item }} state=present"
+  with_items:
+    - python
+    - python-pip
+    - python-virtualenv
+
+- name: Create Pulp Smash virtual environment
+  shell: virtualenv venv chdir=pulp-smash
+
+# mock Pulp Smash requirement requires an updated setuptools
+- name: Update setuptools
+  shell: venv/bin/pip install -U setuptools chdir=pulp-smash
+
+- name: Install Pulp Smash requirements
+  shell: venv/bin/pip install -r requirements.txt pytest chdir=pulp-smash
+
+- name: Configure Pulp Smash
+  template: src=settings.j2 dest=pulp-smash/pulp_smash/settings.json
+
+- name: Run Pulp Smash
+  shell: XDG_CONFIG_DIRS=. venv/bin/py.test --junit-xml=report.xml pulp_smash/tests chdir=pulp-smash

--- a/ci/ansible/roles/pulp-smash/templates/settings.j2
+++ b/ci/ansible/roles/pulp-smash/templates/settings.j2
@@ -1,0 +1,7 @@
+{
+    "default": {
+        "base_url": "{{ pulp_smash_baseurl }}",
+        "auth": ["{{ pulp_smash_username }}", "{{ pulp_smash_password }}"],
+        "verify": {{ pulp_smash_verify }}
+    }
+}

--- a/ci/ansible/roles/pulp/defaults/main.yaml
+++ b/ci/ansible/roles/pulp/defaults/main.yaml
@@ -1,0 +1,10 @@
+---
+
+# Whether to install recommended prerequisites
+pulp_install_prerequisites: true
+
+# Whether to install Pulp server
+pulp_install_server: true
+
+# Pulp version to install
+pulp_version: 2.8

--- a/ci/ansible/roles/pulp/handlers/main.yaml
+++ b/ci/ansible/roles/pulp/handlers/main.yaml
@@ -1,0 +1,28 @@
+---
+
+- name: Restart Apache service
+  service:
+    name: httpd
+    state: restarted
+
+- name: Restart Pulp workers service
+  service:
+    name: pulp_workers
+    state: restarted
+
+- name: Restart Pulp celerybeat service
+  service:
+    name: pulp_celerybeat
+    state: restarted
+  when: pulp_run_celerybeat
+
+- name: Restart Pulp resource manager service
+  service:
+    name: pulp_resource_manager
+    state: restarted
+  when: pulp_run_resource_manager
+
+- name: Restart goferd service
+  service:
+    name: goferd
+    state: restarted

--- a/ci/ansible/roles/pulp/tasks/main.yaml
+++ b/ci/ansible/roles/pulp/tasks/main.yaml
@@ -1,0 +1,37 @@
+---
+
+- name: Ensure expected distribution
+  assert:
+    that: ansible_os_family == "RedHat"
+
+- name: Open firewall ports
+  shell: "iptables -I INPUT -m state --state NEW -p tcp --dport {{ item }} -j ACCEPT"
+  with_items:
+    - 80
+    - 443
+    - 5672
+    - 5671
+  when: pulp_install_prerequisites
+
+- name: Subscription Manager register
+  shell: "subscription-manager register --force --user={{ rhn_username }} --password={{ rhn_password }}"
+  when: ansible_distribution == "RedHat" and rhn_username is defined and rhn_password is defined
+
+- name: Subscription Manager subscribe
+  shell: "subscription-manager subscribe --pool={{ rhn_poolid }}"
+  when: ansible_distribution == "RedHat" and rhn_poolid is defined
+
+- name: Enable optional repository
+  shell: "subscription-manager repos --enable rhel-{{ ansible_distribution_major_version }}-server-optional-rpms"
+  when: ansible_distribution == "RedHat"
+
+- name: Enable extras repository
+  shell: "subscription-manager repos --enable rhel-{{ ansible_distribution_major_version }}-server-extras-rpms"
+  when: ansible_distribution == "RedHat" and ansible_distribution_major_version|int >= 7
+
+- name: Enable EPEL repository
+  action: "{{ ansible_pkg_mgr }} name=https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
+  when: ansible_distribution == "RedHat"
+
+- include: pulp_server.yaml
+  when: pulp_install_server

--- a/ci/ansible/roles/pulp/tasks/pulp_server.yaml
+++ b/ci/ansible/roles/pulp/tasks/pulp_server.yaml
@@ -1,0 +1,81 @@
+---
+
+- name: Install MongoDB server
+  action: "{{ ansible_pkg_mgr }} name=mongodb-server state=latest"
+
+- name: Start and enable MongoDB server service
+  service: name=mongod state=started enabled=yes
+
+- name: Setup qpid custom repo
+  get_url: url=https://copr.fedoraproject.org/coprs/irina/qpid/repo/epel-6/irina-qpid-epel-6.repo dest=/etc/yum.repos.d/irina-qpid.repo
+  when: ansible_distribution == "RedHat" and ansible_distribution_major_version|int == 6
+
+- name: Install qpid-cpp server
+  action: "{{ ansible_pkg_mgr }} name={{ item }} state=latest"
+  with_items:
+    - qpid-cpp-server
+    - qpid-cpp-server-linearstore
+
+- name: Install package for migration 0009
+  action: "{{ ansible_pkg_mgr }} name=qpid-tools state=latest"
+  when: ansible_distribution == "RedHat" and ansible_distribution_major_version|int == 7
+
+- name: Start and enable qpid-cpp server service
+  service: name=qpidd state=started enabled=yes
+
+- name: Setup Pulp repository
+  template:
+    src: yum_repo.j2
+    dest: /etc/yum.repos.d/{{ item.key }}.repo
+  with_dict:
+    pulp:
+      name: Pulp Project repository
+      baseurl: "https://repos.fedorapeople.org/pulp/pulp/testing/automation/{{ pulp_version }}/dev/{% if ansible_distribution == 'Fedora' %}fedora-{% endif %}$releasever/$basearch/"
+
+      gpgcheck: 0
+
+- name: Install Pulp Server
+  action: "{{ ansible_pkg_mgr }} name=@pulp-server-qpid"
+  notify:
+    - Restart Apache service
+    - Restart Pulp workers service
+    - Restart Pulp celerybeat service
+    - Restart Pulp resource manager service
+
+- name: Check if Pulp's DB was initialized
+  stat:
+    path: /var/lib/pulp/db_initialized.flag
+  register: db_init
+
+- name: Initialize Pulp's DB
+  shell: sudo -u apache pulp-manage-db && touch /var/lib/pulp/db_initialized.flag
+  notify:
+    - Restart Apache service
+    - Restart Pulp workers service
+    - Restart Pulp celerybeat service
+    - Restart Pulp resource manager service
+  when: not db_init.stat.exists
+
+- name: Ensure Apache server is running
+  service:
+    name: httpd
+    enabled: yes
+    state: running
+
+- name: Ensure Pulp workers are running
+  service:
+    name: pulp_workers
+    enabled: yes
+    state: running
+
+- name: Ensure Pulp celerybeat is running
+  service:
+    name: pulp_celerybeat
+    enabled: yes
+    state: running
+
+- name: Ensure Pulp resource manager is running
+  service:
+    name: pulp_resource_manager
+    enabled: yes
+    state: running

--- a/ci/ansible/roles/pulp/templates/yum_repo.j2
+++ b/ci/ansible/roles/pulp/templates/yum_repo.j2
@@ -1,0 +1,4 @@
+[{{ item.key }}]
+{% for key, value in item.value.iteritems() | sort -%}
+  {{ key }}={{ value }}
+{% endfor %}


### PR DESCRIPTION
The pulp_smash_automation.yaml is a playbook that benefits of pulp and
pulp-smash roles. The former is a role which deploys pulp server and the
latter is a role which fetch latest Pulp Smash, configure it and run the
tests using py.test.