### PR TITLE
Add pulp_server and pulp_smash playbooks

### DIFF
--- a/ci/ansible/pulp_server.yaml
+++ b/ci/ansible/pulp_server.yaml
@@ -4,5 +4,4 @@
   roles:
     - role: pulp
       pulp_install_server: true
-    - pulp-smash
   sudo: true

--- a/ci/ansible/pulp_smash.yaml
+++ b/ci/ansible/pulp_smash.yaml
@@ -1,0 +1,6 @@
+---
+
+- hosts: all
+  roles:
+    - pulp-smash
+  sudo: true

--- a/ci/ansible/roles/pulp/handlers/main.yaml
+++ b/ci/ansible/roles/pulp/handlers/main.yaml
@@ -14,13 +14,11 @@
   service:
     name: pulp_celerybeat
     state: restarted
-  when: pulp_run_celerybeat
 
 - name: Restart Pulp resource manager service
   service:
     name: pulp_resource_manager
     state: restarted
-  when: pulp_run_resource_manager
 
 - name: Restart goferd service
   service:

--- a/ci/ansible/roles/pulp/tasks/pulp_server.yaml
+++ b/ci/ansible/roles/pulp/tasks/pulp_server.yaml
@@ -13,12 +13,10 @@
 - name: Install qpid-cpp server
   action: "{{ ansible_pkg_mgr }} name={{ item }} state=latest"
   with_items:
+    - python-qpid-qmf
     - qpid-cpp-server
     - qpid-cpp-server-linearstore
-
-- name: Install package for migration 0009
-  action: "{{ ansible_pkg_mgr }} name=qpid-tools state=latest"
-  when: ansible_distribution == "RedHat" and ansible_distribution_major_version|int == 7
+    - qpid-tools
 
 - name: Start and enable qpid-cpp server service
   service: name=qpidd state=started enabled=yes


### PR DESCRIPTION
Also remove pulp_smash_automation playbook to allow running Pulp setup
and Pulp Smash run separated.

In addition update Install packages for migration 009 task to be run on
RHEL6+ and to install python-qpid-qmf. Last but not least, remove
conditional from handlers since it is not needed.