### PR TITLE
Add pulp_smash_version variable

### DIFF
--- a/ci/ansible/roles/pulp-smash/templates/settings.j2
+++ b/ci/ansible/roles/pulp-smash/templates/settings.j2
@@ -2,6 +2,9 @@
     "default": {
         "base_url": "{{ pulp_smash_baseurl }}",
         "auth": ["{{ pulp_smash_username }}", "{{ pulp_smash_password }}"],
+        {% if pulp_smash_version %}
+        "version": "{{ pulp_smash_version }}",
+        {% endif %}
         "verify": {{ pulp_smash_verify }}
     }
 }


### PR DESCRIPTION
The variable is used in order to tell Pulp Smash which Pulp Server
version it is running against.