### PR TITLE
Add Pulp 2.8 permutation

### DIFF
--- a/ci/jobs/pulp-dev.yaml
+++ b/ci/jobs/pulp-dev.yaml
@@ -93,5 +93,6 @@
     pulp_version:
         - 2.6
         - 2.7
+        - 2.8
     jobs:
         - pulp-{pulp_version}-dev-{os}


### PR DESCRIPTION
Add Pulp 2.8 permutation to the Pulp Smash jobs. This will make jobs
being created for Pulp 2.8 for all supported Operating Systems.