### PR TITLE
Adds a trigger to the pulp deployment jobs

### DIFF
--- a/ci/jobs/pulp-dev.yaml
+++ b/ci/jobs/pulp-dev.yaml
@@ -19,6 +19,9 @@
             files:
                 - file-id: rhn_credentials
                   variable: RHN_CREDENTIALS
+    triggers:
+        - reverse:
+              jobs: build-automation-repo-{pulp_version}-dev
     builders:
         - shell: |
             sudo yum install -y git ansible libselinux-python


### PR DESCRIPTION
This patch adds a trigger to all the pulp-{pulp_version}-dev-{os} jobs
to run after build-automation-repo-{pulp_version}-dev jobs.