### PR TITLE
Improve job trigger for Pulp Smash jobs

### DIFF
--- a/ci/jobs/pulp-dev.yaml
+++ b/ci/jobs/pulp-dev.yaml
@@ -21,7 +21,8 @@
                   variable: RHN_CREDENTIALS
     triggers:
         - reverse:
-              jobs: build-automation-repo-{pulp_version}-dev
+            jobs: build-automation-repo-{pulp_version}-dev
+            result: success
     builders:
         - shell: |
             sudo yum install -y git ansible libselinux-python


### PR DESCRIPTION
Even though jenkins-job-builder states on the documentation that the
result have the default value of success it fail when generating the job
configuration if result is omitted.