### PR TITLE
Improve pulp dev jobs

### DIFF
--- a/ci/ansible/roles/pulp-smash/templates/settings.j2
+++ b/ci/ansible/roles/pulp-smash/templates/settings.j2
@@ -5,6 +5,9 @@
         {% if pulp_smash_version %}
         "version": "{{ pulp_smash_version }}",
         {% endif %}
+        {% if pulp_smash_cli_transport %}
+        "cli_transport": "{{ pulp_smash_cli_transport }}",
+        {% endif %}
         "verify": {{ pulp_smash_verify }}
     }
 }

--- a/ci/jobs/pulp-dev.yaml
+++ b/ci/jobs/pulp-dev.yaml
@@ -34,6 +34,8 @@
                 -e "rhn_password=${{RHN_PASSWORD}}" \
                 -e "rhn_poolid=${{RHN_POOLID}}" \
                 --connection=local
+            ssh-keygen -t rsa -N "" -f pulp_server_key
+            cat pulp_server_key.pub >> ~/.ssh/authorized_keys
             echo ${{SSH_CONNECTION}} | awk '{{ print "BASE_URL=https://"$3 }}' >> parameters.txt
         - inject:
             properties-file: parameters.txt
@@ -48,6 +50,11 @@
                   build-step-failure-threshold: never
                   unstable-threshold: never
                   failure-threshold: never
+              parameter-factories:
+                  - factory: binaryfile
+                    parameter-name: PRIVATE_KEY
+                    file-pattern: pulp_server_key
+                    no-files-found-action: FAIL
         - copyartifact:
             project: pulp-smash-runner
             which-build: specific-build
@@ -73,18 +80,43 @@
             name: BASE_URL
         - string:
             name: PULP_VERSION
-            decription: |
-                Pulp version setup on the server.
+            decription: Pulp version setup on the server.
+        - file:
+            name: PRIVATE_KEY
+            description: Private ssh key to connect on the server.
     scm:
         - pulp-packaging
     builders:
         - shell: |
-            sudo yum install -y git ansible
-            echo 'localhost' > hosts
-            ansible-playbook -i hosts ci/ansible/pulp_smash.yaml \
-                -e pulp_smash_baseurl=${BASE_URL} \
-                -e pulp_smash_version=${PULP_VERSION} \
-                --connection=local
+            # Setup ssh config and private key
+            cat > ~/.ssh/config <<EOF
+            Host $(echo ${BASE_URL} | cut -d/ -f3)
+                User jenkins
+                StrictHostKeyChecking no
+                UserKnownHostsFile /dev/null
+                IdentityFile ${PWD}/PRIVATE_KEY
+            EOF
+            chmod 600 PRIVATE_KEY ~/.ssh/config
+
+            sudo yum -y install python-pip python-virtualenv
+            virtualenv venv
+            source venv/bin/activate
+            pip install -U setuptools
+            pip install -r requirements.txt pytest
+
+            mkdir -p pulp_smash
+            cat > pulp_smash/settings.json <<EOF
+            {
+                "default": {
+                    "base_url": "${BASE_URL}",
+                    "auth": ["admin", "admin"],
+                    "version": "${PULP_VERSION}",
+                    "cli_transport": "ssh",
+                    "verify": false
+                }
+            }
+            EOF
+            XDG_CONFIG_DIRS=. py.test -v --junit-xml=report.xml pulp_smash/tests
     publishers:
         - archive:
             artifacts: 'ci/ansible/pulp-smash/report.xml'


### PR DESCRIPTION
Added two commits to 1) make pulp-dev jobs configure ssh connection to the server and allow pulp-smash-runner to ssh into it and 2) update the pulp-smash ansible role to accept the recent added cli_transport setting.