### PR TITLE
IRC notifications only for parent job

### DIFF
--- a/ci/jobs/macros.yaml
+++ b/ci/jobs/macros.yaml
@@ -4,3 +4,4 @@
       - ircbot:
           strategy: all
           message-type: summary-scm
+          matrix-notifier: only-parent


### PR DESCRIPTION
Without this, all sub-jobs get notifications, which will be *very*
spammy.