### PR TITLE
more irc notify tweaks

### DIFF
--- a/ci/jobs/ci-build-repo.yaml
+++ b/ci/jobs/ci-build-repo.yaml
@@ -63,7 +63,7 @@
               ./build-all.py {release_config}
             fi
     publishers:
-      - irc-notify-all-summary-scm
+      - irc-notify-all-summary
       # Take the node offline so that another build doesn't pile on
       - groovy-postbuild: "manager.build.getBuiltOn().toComputer().setTemporarilyOffline(true)"
 

--- a/ci/jobs/ci-continuous.yaml
+++ b/ci/jobs/ci-continuous.yaml
@@ -153,7 +153,7 @@
           results: 'test/*.xml'
           keep-long-stdio: true
           test-stability: true
-      - irc-notify-all-summary-scm
+      - irc-notify-failedfixed-summary
       # Take the node offline so that another build doesn't pile on
       - groovy-postbuild:
           script: "manager.build.getBuiltOn().toComputer().setTemporarilyOffline(true)"
@@ -304,7 +304,7 @@
           results: 'test/*.xml'
           keep-long-stdio: true
           test-stability: true
-      - irc-notify-all-summary-scm
+      - irc-notify-failedfixed-summary
       # Take the node offline so that another build doesn't pile on
       - groovy-postbuild:
           script: "manager.build.getBuiltOn().toComputer().setTemporarilyOffline(true)"

--- a/ci/jobs/macros.yaml
+++ b/ci/jobs/macros.yaml
@@ -1,7 +1,19 @@
+# notify the default channel with a build summary on all build states (pass/unstable/fail)
+# good for things like nightly builds since it always reports
 - publisher:
-    name: irc-notify-all-summary-scm
+    name: irc-notify-all-summary
     publishers:
       - ircbot:
           strategy: all
-          message-type: summary-scm
+          message-type: summary
+          matrix-notifier: only-parent
+
+# notify the default channel with a build summary on new failure/fixed build states
+# good for per-commit things like PR testers since it only reports on status changes
+- publisher:
+    name: irc-notify-failedfixed-summary
+    publishers:
+      - ircbot:
+          strategy: new-failure-and-fixed
+          message-type: summary
           matrix-notifier: only-parent

--- a/ci/jobs/pulp-dev.yaml
+++ b/ci/jobs/pulp-dev.yaml
@@ -63,7 +63,7 @@
     publishers:
         - junit:
             results: report.xml
-        - irc-notify-all-summary-scm
+        - irc-notify-all-summary
         # Take the node offline so that another build doesn't pile on
         - groovy-postbuild:
             script: "manager.build.getBuiltOn().toComputer().setTemporarilyOffline(true)"


### PR DESCRIPTION
pr notifications should be less spammy for failing PRs, because it only
reports when a job switches from passing to failed (or vice versa); it
doesn't report on repeating failures. package builds will still always
report, and all notifications no longer include commit info