### PR TITLE
Add qpid COPR repository on all EL6-based distributions.

### DIFF
--- a/ci/ansible/roles/pulp/tasks/pulp_server.yaml
+++ b/ci/ansible/roles/pulp/tasks/pulp_server.yaml
@@ -10,7 +10,7 @@
 
 - name: Setup qpid custom repo
   get_url: url=https://copr.fedoraproject.org/coprs/irina/qpid/repo/epel-6/irina-qpid-epel-6.repo dest=/etc/yum.repos.d/irina-qpid.repo
-  when: ansible_distribution == "RedHat" and ansible_distribution_major_version|int == 6
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 6
 
 - name: Install qpid-cpp server
   action: "{{ ansible_pkg_mgr }} name={{ item }} state=latest"


### PR DESCRIPTION
All Enterprise Linux 6 distributions (RHEL, Centos, Scientific Linux,
etc) need to use the version of qpid-cpp-server that ships in the COPR
repository maintained by the Qpid team. This ensures that any
distribution in the 'RedHat' OS family (with a major release equal to
6) have the repository added.