### PR TITLE
Restrict lazy role to run only for Pulp 2.8+

### DIFF
--- a/ci/ansible/pulp_server.yaml
+++ b/ci/ansible/pulp_server.yaml
@@ -5,4 +5,5 @@
     - role: pulp
       pulp_install_server: true
     - role: lazy
+      when: pulp_version|float >= 2.8
   sudo: true

--- a/ci/ansible/roles/lazy/tasks/main.yml
+++ b/ci/ansible/roles/lazy/tasks/main.yml
@@ -8,11 +8,11 @@
 
 - name: Install squid proxy configuration
   copy: src=squid.conf dest=/etc/squid/squid.conf
-  when:  ansible_os_family == "RedHat" and ansible_distribution_major_version|int > 6
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int > 6
 
 - name: Install squid-3.1 proxy configuration
   copy: src=squid-3.1.conf dest=/etc/squid/squid.conf
-  when:  ansible_os_family == "RedHat" and ansible_distribution_major_version == "6"
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "6"
 
 - file: path=/var/spool/squid state=directory owner=squid group=squid mode=750
 


### PR DESCRIPTION
Lazy Sync feature is only available on Pulp 2.8+, because this the lazy
role should just run when installing Pulp 2.8+.