### PR TITLE
Add certificate setup support to Ansible and the Jenkies job.

### DIFF
--- a/ci/ansible/pulp_server.yaml
+++ b/ci/ansible/pulp_server.yaml
@@ -6,4 +6,5 @@
       pulp_install_server: true
     - role: lazy
       when: pulp_version|float >= 2.8
+    - role: pulp-certs
   sudo: true

--- a/ci/ansible/roles/pulp-certs/tasks/main.yml
+++ b/ci/ansible/roles/pulp-certs/tasks/main.yml
@@ -1,0 +1,55 @@
+---
+- name: Create CA to sign all certificates
+  command: >
+    /usr/bin/openssl req -x509 -newkey rsa:2048 -keyout private/cakey.pem -nodes -days 3650
+     -out cacert.pem -subj '/C=US/ST=North Carolina/L=Raleigh/O=Pulp/OU=Development/CN=PulpCA'
+  args:
+    chdir: /etc/pki/CA/
+    creates: cacert.pem
+
+- name: Create CA index.txt
+  command: /usr/bin/touch /etc/pki/CA/index.txt creates=/etc/pki/CA/index.txt
+
+- name: Add CA to trust store
+  shell: >
+    /usr/bin/cp /etc/pki/CA/cacert.pem /etc/pki/ca-trust/source/anchors/cacert.pem &&
+    /usr/bin/update-ca-trust
+  args:
+    creates: /etc/pki/ca-trust/source/anchors/cacert.pem
+
+- name: Configure openssl subjectAltName
+  lineinfile: dest=/etc/pki/tls/openssl.cnf
+              insertafter="^\[ usr_cert \]"
+              line="subjectAltName=DNS:{{ansible_fqdn}}"
+
+- name: Create Apache certificate request
+  command: >
+    /usr/bin/openssl req -newkey rsa:2048 -keyout private/apachekey.pem -nodes -days 365
+    -out certs/apachereq.pem \
+    -subj '/C=US/ST=North Carolina/L=Raleigh/O=Pulp/OU=Development/CN={{ansible_hostname}}'
+  args:
+    chdir: /etc/pki/tls/
+    creates: certs/apachereq.pem
+
+- name: Sign Apache certificate
+  command: >
+    /usr/bin/openssl ca -create_serial -in /etc/pki/tls/certs/apachereq.pem
+    -out /etc/pki/tls/certs/apachecert.pem -days 365 -keyfile /etc/pki/CA/private/cakey.pem -batch
+  args:
+    chdir: /etc/pki/tls/
+    creates: certs/apachecert.pem
+
+# In the distant future when Ansible sets everything up, this should notify httpd
+- name: Configure Apache TLS certificate
+  lineinfile:
+      backrefs: yes
+      dest: /etc/httpd/conf.d/ssl.conf
+      regexp: "^SSLCertificateFile "
+      line: "SSLCertificateFile /etc/pki/tls/certs/apachecert.pem"
+
+- name: Configure Apache TLS private key
+  lineinfile:
+      backrefs: yes
+      dest: /etc/httpd/conf.d/ssl.conf
+      regexp: "^SSLCertificateKeyFile "
+      line: "SSLCertificateKeyFile /etc/pki/tls/private/apachekey.pem"

--- a/ci/jobs/pulp-dev.yaml
+++ b/ci/jobs/pulp-dev.yaml
@@ -38,6 +38,7 @@
                 -e "rhn_poolid=${{RHN_POOLID}}" \
                 -e "rhn_atomic_poolid=${{RHN_ATOMIC_POOLID}}" \
             echo ${{SSH_CONNECTION}} | awk '{{ print "BASE_URL=https://"$3 }}' >> parameters.txt
+            cp /etc/pki/CA/cacert.pem cacert.pem
         - inject:
             properties-file: parameters.txt
         - trigger-builds:
@@ -55,6 +56,10 @@
                   - factory: binaryfile
                     parameter-name: PRIVATE_KEY
                     file-pattern: pulp_server_key
+                    no-files-found-action: FAIL
+                  - factory: binaryfile
+                    parameter-name: CA_CERT
+                    file-pattern: cacert.pem
                     no-files-found-action: FAIL
         - copyartifact:
             project: pulp-smash-runner
@@ -86,6 +91,9 @@
         - file:
             name: PRIVATE_KEY
             description: Private ssh key to connect on the server.
+        - file:
+            name: CA_CERT
+            description: The CA certificate that signed the Pulp apache server.
     scm:
         - pulp-packaging
     builders:
@@ -99,6 +107,10 @@
                 IdentityFile ${PWD}/PRIVATE_KEY
             EOF
             chmod 600 PRIVATE_KEY ~/.ssh/config
+
+            # Set up the CA certificate that signed Pulp's apache server.
+            sudo cp CA_CERT /etc/pki/ca-trust/source/anchors/cacert.pem
+            sudo update-ca-trust
 
             sudo yum -y install python-pip python-virtualenv
             virtualenv venv
@@ -116,7 +128,7 @@
                     "auth": ["admin", "admin"],
                     "version": "${PULP_VERSION}",
                     "cli_transport": "ssh",
-                    "verify": false
+                    "verify": true
                 }
             }
             EOF


### PR DESCRIPTION
This sets up a CA and a certificate for Apache to use, trusts the CA
certificate on the Pulp machine, and ensures it gets exported as a
parameter in the Jenkies job. It also has the pulp-smash runner trust
the CA.
