### PR TITLE
Added a release config file for 2.8.0 branches

### DIFF
--- a/ci/config/releases/280.yaml
+++ b/ci/config/releases/280.yaml
@@ -4,22 +4,29 @@ repositories:
   - name: pulp
     external_deps: deps/external_deps.json
     git_url: git@github.com:pulp/pulp.git
-    git_branch: master
+    git_branch: 2.8.0
+    parent_branch: master
   - name: pulp_puppet
     git_url: git@github.com:pulp/pulp_puppet.git
-    git_branch: master
+    git_branch: 2.8.0
+    parent_branch: master
   - name: pulp_rpm
     git_url: git@github.com:pulp/pulp_rpm.git
-    git_branch: master
+    git_branch: 2.8.0
+    parent_branch: master
   - name: pulp_docker
     git_url: git@github.com:pulp/pulp_docker.git
-    git_branch: master
+    git_branch: 2.0.0
+    parent_branch: master
   - name: crane
     git_url: git@github.com:pulp/crane.git
-    git_branch: master
+    git_branch: 2.0.0
+    parent_branch: master
   - name: pulp_ostree
     git_url: git@github.com:pulp/pulp_ostree.git
-    git_branch: master
+    git_branch: 1.1.0
+    parent_branch: master
   - name: pulp_python
     git_url: git@github.com:pulp/pulp_python.git
-    git_branch: master
+    git_branch: 1.1.0
+    parent_branch: master


### PR DESCRIPTION
This adds a new release config for 2.8.0. Also adjusts the 2.8-dev.yaml to not reference pulp_deb.