### PR TITLE
Add pulp-coverage role

### DIFF
--- a/ci/ansible/pulp_coverage.yaml
+++ b/ci/ansible/pulp_coverage.yaml
@@ -1,0 +1,5 @@
+---
+- hosts: all
+  roles:
+    - role: pulp-coverage
+  sudo: true

--- a/ci/ansible/roles/pulp-coverage/defaults/main.yaml
+++ b/ci/ansible/roles/pulp-coverage/defaults/main.yaml
@@ -1,0 +1,17 @@
+# Define what action to perform
+#
+# Possible values are:
+#  * install: to install the coverage hook
+#  * report: to generate the coverage report
+#  * uninstall: to uninstall the coverage hook
+pulp_coverage_action: "install"
+
+# Directory where the coverage report is going to be created
+pulp_coverage_report_dir: "."
+
+# Services that need to be managed in order to coverage work
+pulp_coverage_services:
+  - httpd
+  - pulp_workers
+  - pulp_celerybeat
+  - pulp_resource_manager

--- a/ci/ansible/roles/pulp-coverage/tasks/install.yaml
+++ b/ci/ansible/roles/pulp-coverage/tasks/install.yaml
@@ -1,0 +1,37 @@
+---
+- name: Stop services
+  service:
+    name: "{{ item }}"
+    state: stopped
+  with_items: "{{ pulp_coverage_services }}"
+
+- name: Clean up previous coverage data
+  file:
+    path: /srv/pulp_coverage
+    state: absent
+
+- name: Create Pulp coverage directory
+  file:
+    mode: 1777
+    path: /srv/pulp_coverage
+    state: directory
+
+- name: Clone coverage repository
+  git:
+    repo: https://github.com/pulp/pulp.git
+    dest: pulp
+    depth: 1
+
+- name: Install coverage package
+  action: "{{ ansible_pkg_mgr }} name=python-coverage state=latest"
+
+- name: Install the coverage hook
+  command: ./coverage_hook install
+  args:
+    chdir: pulp/playpen/coverage
+
+- name: Start services
+  service:
+    name: "{{ item }}"
+    state: started
+  with_items: "{{ pulp_coverage_services }}"

--- a/ci/ansible/roles/pulp-coverage/tasks/main.yaml
+++ b/ci/ansible/roles/pulp-coverage/tasks/main.yaml
@@ -1,0 +1,9 @@
+---
+- include: install.yaml
+  when: pulp_coverage_action == "install"
+
+- include: report.yaml
+  when: pulp_coverage_action == "report"
+
+- include: uninstall.yaml
+  when: pulp_coverage_action == "uninstall"

--- a/ci/ansible/roles/pulp-coverage/tasks/report.yaml
+++ b/ci/ansible/roles/pulp-coverage/tasks/report.yaml
@@ -1,0 +1,22 @@
+---
+- name: Stop services
+  service:
+    name: "{{ item }}"
+    state: stopped
+  with_items: "{{ pulp_coverage_services }}"
+
+- name: Generate the coverage report
+  command: "./coverage_hook report {{ pulp_coverage_report_dir }}"
+  args:
+    chdir: pulp/playpen/coverage
+
+- name: Remove old coverage data
+  file:
+    path: /srv/pulp_coverage/*
+    state: absent
+
+- name: Start services
+  service:
+    name: "{{ item }}"
+    state: started
+  with_items: "{{ pulp_coverage_services }}"

--- a/ci/ansible/roles/pulp-coverage/tasks/uninstall.yaml
+++ b/ci/ansible/roles/pulp-coverage/tasks/uninstall.yaml
@@ -1,0 +1,16 @@
+---
+- name: Uninstall the coverage hook
+  command: ./coverage_hook uninstall
+  args:
+    chdir: pulp/playpen/coverage
+
+- name: Remove coverage directory
+  file:
+    path: /srv/pulp_coverage
+    state: absent
+
+- name: Restart services
+  service:
+    name: "{{ item }}"
+    state: restarted
+  with_items: "{{ pulp_coverage_services }}"


### PR DESCRIPTION
This role is responsible for installing and uninstalling the coverage
report capturing on a Pulp installation. It also generates and captures
the coverage report.