### PR TITLE
Capture coverage information for Pulp 2.8

### DIFF
--- a/ci/jobs/pulp-dev.yaml
+++ b/ci/jobs/pulp-dev.yaml
@@ -36,7 +36,10 @@
                 -e "rhn_username=${{RHN_USERNAME}}" \
                 -e "rhn_password=${{RHN_PASSWORD}}" \
                 -e "rhn_poolid=${{RHN_POOLID}}" \
-                -e "rhn_atomic_poolid=${{RHN_ATOMIC_POOLID}}" \
+                -e "rhn_atomic_poolid=${{RHN_ATOMIC_POOLID}}"
+            if [ "{pulp_version}" = "2.8" ]; then
+                ansible-playbook --private-key pulp_server_key -i hosts ci/ansible/pulp_coverage.yaml
+            fi
             echo ${{SSH_CONNECTION}} | awk '{{ print "BASE_URL=https://"$3 }}' >> parameters.txt
         - inject:
             properties-file: parameters.txt
@@ -61,9 +64,28 @@
             which-build: specific-build
             build-number: ${{TRIGGERED_BUILD_NUMBER_PULP_SMASH_RUNNER}}
             flatten: true
+        - shell: |
+            if [ "{pulp_version}" = "2.8" ]; then
+                ansible-playbook --private-key pulp_server_key -i hosts ci/ansible/pulp_coverage.yaml \
+                    -e pulp_coverage_action=report \
+                    -e pulp_coverage_report_dir=/tmp \
+                    -e pulp_coverage_report_xml=true
+                cp /tmp/report.xml coverage.xml
+            fi
     publishers:
         - junit:
             results: nose2-junit.xml
+        - cobertura:
+            report-file: "coverage.xml"
+            targets:
+                - files:
+                    healthy: 10
+                    unhealthy: 20
+                    failing: 30
+                - method:
+                    healthy: 50
+                    unhealthy: 40
+                    failing: 30
         - irc-notify-all-summary
         # Take the node offline so that another build doesn't pile on
         - groovy-postbuild:


### PR DESCRIPTION
Install the pulp coverage when installing Pulp 2.8 and include the
cobertura publisher in order to publish coverage results for Pulp 2.8
jobs.