### PR TITLE
Install coverage using pip

### DIFF
--- a/ci/ansible/roles/pulp-coverage/tasks/install.yaml
+++ b/ci/ansible/roles/pulp-coverage/tasks/install.yaml
@@ -22,8 +22,11 @@
     dest: pulp
     depth: 1
 
+- name: Install pip package
+  action: "{{ ansible_pkg_mgr }} name=python-pip state=latest"
+
 - name: Install coverage package
-  action: "{{ ansible_pkg_mgr }} name=python-coverage state=latest"
+  command: pip install -U coverage
 
 - name: Install the coverage hook
   command: ./coverage_hook install


### PR DESCRIPTION
Use pip to install coverage Python package in order to ensure the latest
version. This is needed because on RHEL the version available is 3.x
while the version needed for the coverage hook is 4+.