### PR TITLE
Fix logging capture on Pulp Automation

### DIFF
--- a/ci/jobs/pulp-dev.yaml
+++ b/ci/jobs/pulp-dev.yaml
@@ -74,8 +74,8 @@
             fi
         - conditional-step:
             condition-kind: current-status
-            condition-worst: UNSTABLE
-            condition-best: FAILURE
+            condition-worst: FAILURE
+            condition-best: UNSTABLE
             steps:
                 - shell: |
                     rm -rf logs


### PR DESCRIPTION
Make sure to proper configure the conditional step in order to make it
capture the logging files.