### PR TITLE
Change back pulp-smash-runner to run parallel

### DIFF
--- a/ci/jobs/pulp-dev.yaml
+++ b/ci/jobs/pulp-dev.yaml
@@ -10,7 +10,6 @@
 
 - job-template:
     name: 'pulp-{pulp_version}-dev-{os}'
-    concurrent: false
     node: '{os}-vanilla-np'
     scm:
         - pulp-packaging
@@ -113,7 +112,7 @@
 
 - job:
     name: pulp-smash-runner
-    concurrent: false
+    concurrent: true
     properties:
         - copyartifact:
             projects: pulp-*-dev-*


### PR DESCRIPTION
Get results faster by running more than one pulp-smash-runner.