### PR TITLE
Capture logs for every Pulp Smash job run

### DIFF
--- a/ci/jobs/pulp-dev.yaml
+++ b/ci/jobs/pulp-dev.yaml
@@ -81,22 +81,17 @@
             steps:
                 - sonar:
                     sonar-name: 'Sonar Test Server'
-        - conditional-step:
-            condition-kind: current-status
-            condition-worst: FAILURE
-            condition-best: UNSTABLE
-            steps:
-                - shell: |
-                    rm -rf logs
-                    mkdir logs
-                    if [ $(which journalctl1 &> /dev/null) ]; then
-                        journalctl > logs/syslog
-                    else
-                        cat /var/log/messages > logs/syslog
-                    fi
-                    [ -e /var/log/httpd ] && cp /var/log/httpd logs
-                    [ -e /var/log/squid ] && cp /var/log/squid logs
-                    tar -zcf logs.tar.gz logs
+        - shell: |
+            rm -rf logs
+            mkdir logs
+            if [ $(which journalctl1 &> /dev/null) ]; then
+                journalctl > logs/syslog
+            else
+                cat /var/log/messages > logs/syslog
+            fi
+            [ -e /var/log/httpd ] && cp /var/log/httpd logs
+            [ -e /var/log/squid ] && cp /var/log/squid logs
+            tar -zcf logs.tar.gz logs
     publishers:
         - junit:
             results: nose2-junit.xml


### PR DESCRIPTION
The build status becomes unstable or failed when the jUnit report is publish.
Because that, the logging were not being captured in any circumstance.