### PR TITLE
Skip coverage report on RHEL6

### DIFF
--- a/ci/jobs/pulp-dev.yaml
+++ b/ci/jobs/pulp-dev.yaml
@@ -63,7 +63,10 @@
             build-number: ${{TRIGGERED_BUILD_NUMBER_PULP_SMASH_RUNNER}}
             flatten: true
         - shell: |
-            if [ "${{PULP_VERSION}}" = "2.8" ]; then
+            # Coverage report is introduced on Pulp 2.8 and requires Python
+            # version 2.7+. Run the coverage report only if the system being
+            # tested matches the required environment.
+            if [ "${{PULP_VERSION}}" = "2.8" ] && [ "${{OS}}" != "rhel6"]; then
                 ansible-playbook --private-key pulp_server_key -i hosts ci/ansible/pulp_coverage.yaml \
                     -e pulp_coverage_action=report \
                     -e pulp_coverage_report_dir=/tmp \


### PR DESCRIPTION
The Python version available on RHEL6 is Python 2.6 which is a really old
version and the coverage report doesn't run on that version. Is better to skip
capturing the coverage report on that OS version in order to avoid the build to
fail and not publish the jUnit XML report.