### PR TITLE
Update the plugins unittest template name

### DIFF
--- a/ci/jobs/projects.yaml
+++ b/ci/jobs/projects.yaml
@@ -43,7 +43,7 @@
     name: unittests
     jobs:
      - 'unittest-pulp-pr'
-     - 'unittest-plugins-pr-jobs'
+     - 'unittest-{pulp_plugin}-pr'
     pulp_plugin:
       - pulp_deb:
           min_coverage: 100


### PR DESCRIPTION
Update the plugins unittest template name on unittests project in order to
match the right job.