### PR TITLE
Add github.com to known_hosts

### DIFF
--- a/ci/jobs/build-automation.yaml
+++ b/ci/jobs/build-automation.yaml
@@ -41,6 +41,11 @@
             git config --global user.name "pulpbot"
             git config --global push.default simple
             set -x
+
+            # Add github.com as a known host
+            echo "github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==" >> /home/jenkins/.ssh/known_hosts
+            chmod 644 /home/jenkins/.ssh/known_hosts
+
             env
             cd $WORKSPACE
 


### PR DESCRIPTION
Add github.com as a known host in order to clone repositories using git+ssh
properly.