### PR TITLE
Use Ansible's ``file`` module

### DIFF
--- a/ci/ansible/roles/pulp-certs/tasks/main.yml
+++ b/ci/ansible/roles/pulp-certs/tasks/main.yml
@@ -8,7 +8,7 @@
     creates: cacert.pem
 
 - name: Create CA index.txt
-  command: /usr/bin/touch /etc/pki/CA/index.txt creates=/etc/pki/CA/index.txt
+  file: path=/etc/pki/CA/index.txt state=touch owner=root group=root mode=0644
 
 - name: Add CA to trust store
   shell: >


### PR DESCRIPTION
Previously /etc/pki/CA/index.txt was being created with ``command``. This
led to problems (and was lazy of me to use in the first place) on EL6
because ``touch`` is ``/bin/touch`` rather than ``/usr/bin/touch``.