### PR TITLE
determine which PKG_MGR works to select one

### DIFF
--- a/ci/nodepool/scripts/bootstrap.sh
+++ b/ci/nodepool/scripts/bootstrap.sh
@@ -6,7 +6,14 @@ export DISTRIBUTION=$(python -c "import platform, sys
 sys.stdout.write(platform.dist()[0])")
 export DISTRIBUTION_MAJOR_VERSION=$(python -c "import platform, sys
 sys.stdout.write(platform.dist()[1].split('.')[0])")
-export PKG_MGR=$(which dnf 2>/dev/null || which yum 2>/dev/null)
+
+# use dnf if you can, otherwise use yum
+if dnf --version; then
+    PKG_MGR=dnf
+else
+    PKG_MGR=yum
+fi
+export PKG_MGR
 
 # Create the jenkins user in the jenkins group
 sudo useradd --user-group --create-home --home-dir /home/jenkins jenkins


### PR DESCRIPTION
I took another stab at generating nodepool images in CIOS, and found
that PKG_MGR wasn't getting set because apparently "which" isn't
installed in the f22 images there. I tweaked it to be what's here, which
is "use dnf if you can, otherwise use yum".