### PR TITLE
Fix SSL errors on pulp-smash-runner job

### DIFF
--- a/ci/jobs/pulp-dev.yaml
+++ b/ci/jobs/pulp-dev.yaml
@@ -33,7 +33,7 @@
             if [ "${{PULP_VERSION}}" = "2.8" ] && [ "${{OS}}" != "rhel6"]; then
                 ansible-playbook --private-key pulp_server_key -i hosts ci/ansible/pulp_coverage.yaml
             fi
-            echo ${{SSH_CONNECTION}} | awk '{{ print "BASE_URL=https://"$3 }}' >> parameters.txt
+            echo "BASE_URL=https://$(hostname --fqdn)" >> parameters.txt
             cp /etc/pki/CA/cacert.pem cacert.pem
         - inject:
             properties-file: parameters.txt
@@ -168,7 +168,7 @@
                     "auth": ["admin", "admin"],
                     "version": "${PULP_VERSION}",
                     "cli_transport": "ssh",
-                    "verify": true
+                    "verify": "/etc/pki/ca-trust/source/anchors/cacert.pem"
                 }
             }
             EOF


### PR DESCRIPTION
Pass the hostname of the Pulp server machine instead of the IP address and use
the certificate when doing HTTP requests trough python-requests.