### PR TITLE
Update Pulp Automation jobs

### DIFF
--- a/ci/ansible/roles/pulp/tasks/main.yaml
+++ b/ci/ansible/roles/pulp/tasks/main.yaml
@@ -18,7 +18,7 @@
   when: ansible_distribution == "RedHat" and rhn_username is defined and rhn_password is defined
 
 - name: Subscription Manager subscribe
-  shell: "subscription-manager subscribe --pool={{ rhn_poolid }} --pool={{ rhn_atomic_poolid }}"
+  shell: "subscription-manager subscribe --pool={{ rhn_poolid }}"
   when: ansible_distribution == "RedHat" and rhn_poolid is defined
 
 - name: Enable optional repository

--- a/ci/jobs/pulp-dev.yaml
+++ b/ci/jobs/pulp-dev.yaml
@@ -28,8 +28,7 @@
                 -e pulp_version={pulp_version} \
                 -e "rhn_username=${{RHN_USERNAME}}" \
                 -e "rhn_password=${{RHN_PASSWORD}}" \
-                -e "rhn_poolid=${{RHN_POOLID}}" \
-                -e "rhn_atomic_poolid=${{RHN_ATOMIC_POOLID}}"
+                -e "rhn_poolid=${{RHN_POOLID}}"
             if [ "${{PULP_VERSION}}" = "2.8" ] && [ "${{OS}}" != "rhel6" ]; then
                 ansible-playbook --private-key pulp_server_key -i hosts ci/ansible/pulp_coverage.yaml
             fi
@@ -73,9 +72,9 @@
                     -e pulp_coverage_report_xml=true
                 cp /tmp/report.xml coverage.xml
             fi
-            if [[ "${{OS}}" =~ "rhel[0-9]" ]]; then
-                subscription-manager unregister
-                subscription-manager clean
+            if [[ "${{OS}}" =~ "rhel" ]]; then
+                sudo subscription-manager unregister
+                sudo subscription-manager clean
             fi
         - conditional-step:
             condition-kind: regex-match


### PR DESCRIPTION
Remove the need of an additional pool for atomic on the Pulp Ansible Role.

Because the update of the Pulp Ansible Role, update the pulp automation jobs to
pass the expected information to the playbook.

Finally update the unsubscribe procedure for RHEL based machines in order to
make it really run.