### PR TITLE
Update puppet installation for prepare_node.sh

### DIFF
--- a/ci/nodepool/nodepool.yaml
+++ b/ci/nodepool/nodepool.yaml
@@ -102,7 +102,7 @@ providers:
         private-key: /home/nodepool/.ssh/id_pulp_rsa
         min-ram: 4096
       - name: f22-vanilla-np
-        base-image: fedora-cloud-base-22-20150521.x86_64
+        base-image: Fedora-Cloud-Base-22-20150521.x86_64
         user: jenkins
         setup: prepare_node.sh
         private-key: /home/nodepool/.ssh/id_pulp_rsa


### PR DESCRIPTION
Update the puppet repository URL to new format where the package collection is
specified. And use the changed path for the puppet binaries, for more
information check the documentation [1].

[1] https://docs.puppet.com/puppet/4.4/reference/whered_it_go.html