### PR TITLE
Fix pulp automation logging capture typo

### DIFF
--- a/ci/jobs/pulp-dev.yaml
+++ b/ci/jobs/pulp-dev.yaml
@@ -88,7 +88,7 @@
         - shell: |
             rm -rf logs
             mkdir logs
-            if [ $(which journalctl1 &> /dev/null) ]; then
+            if [ "$(which journalctl 2>/dev/null)" ]; then
                 journalctl > logs/syslog
             else
                 cat /var/log/messages > logs/syslog


### PR DESCRIPTION
```
[root@rhel6 ~]# if [ "$(which journalctl 2>/dev/null)" ]; then echo ok; else echo notok; fi
notok
```

```
[root@rhel7 ~]# if [ "$(which journalctl 2>/dev/null)" ]; then echo ok; else echo notok; fi
ok
```
