### PR TITLE
Improve logging capture for Pulp Automation

### DIFF
--- a/ci/jobs/pulp-dev.yaml
+++ b/ci/jobs/pulp-dev.yaml
@@ -89,12 +89,18 @@
             rm -rf logs
             mkdir logs
             if [ "$(which journalctl 2>/dev/null)" ]; then
-                journalctl > logs/syslog
+                sudo journalctl > logs/syslog
             else
-                cat /var/log/messages > logs/syslog
+                if [ -f /var/log/messages ]; then
+                    sudo cat /var/log/messages > logs/syslog
+                else
+                    echo "Failed to get syslogs: neither journalctl nor" \
+                    "/var/log/messages were found." > logs/syslogs
+                fi
             fi
-            [ -e /var/log/httpd ] && cp /var/log/httpd logs
-            [ -e /var/log/squid ] && cp /var/log/squid logs
+            [ -e /var/log/httpd ] && sudo cp -R /var/log/httpd logs
+            [ -e /var/log/squid ] && sudo cp -R /var/log/squid logs
+            sudo chown -R "${{USER}}":"${{USER}}" logs
             tar -zcf logs.tar.gz logs
     publishers:
         - junit:


### PR DESCRIPTION
Make sure to use `sudo` when needed and proper set permissions in order to
capture the logs.