### PR TITLE
Add Pulp 2.9 Automation

### DIFF
--- a/ci/ansible/roles/pulp/defaults/main.yaml
+++ b/ci/ansible/roles/pulp/defaults/main.yaml
@@ -7,4 +7,4 @@ pulp_install_prerequisites: true
 pulp_install_server: true
 
 # Pulp version to install
-pulp_version: 2.8
+pulp_version: 2.9

--- a/ci/jobs/projects.yaml
+++ b/ci/jobs/projects.yaml
@@ -28,9 +28,11 @@
         - rhel6
         - rhel7
     pulp_version:
-        - 2.6
         - 2.7
         - 2.8
+        - 2.9:
+            reverse_trigger: 'master'
+    reverse_trigger: '{pulp_version}-dev'
     jobs:
         - pulp-{pulp_version}-dev-{os}
 

--- a/ci/jobs/pulp-dev.yaml
+++ b/ci/jobs/pulp-dev.yaml
@@ -14,7 +14,7 @@
                 PULP_VERSION={pulp_version}
     triggers:
         - reverse:
-            jobs: 'build-automation-repo-{pulp_version}-dev'
+            jobs: 'build-automation-repo-{reverse_trigger}'
             result: 'success'
     builders:
         - shell: |
@@ -29,7 +29,7 @@
                 -e "rhn_username=${{RHN_USERNAME}}" \
                 -e "rhn_password=${{RHN_PASSWORD}}" \
                 -e "rhn_poolid=${{RHN_POOLID}}"
-            if [ "${{PULP_VERSION}}" = "2.8" ] && [ "${{OS}}" != "rhel6" ]; then
+            if [ "$(echo -e \"2.8\n${{PULP_VERSION}}\" | sort -V | head -n 1)" = "2.8" ] && [ "${{OS}}" != "rhel6" ]; then
                 ansible-playbook --private-key pulp_server_key -i hosts ci/ansible/pulp_coverage.yaml
             fi
             echo "BASE_URL=https://$(hostname --short)" >> parameters.txt
@@ -65,7 +65,7 @@
             # Coverage report is introduced on Pulp 2.8 and requires Python
             # version 2.7+. Run the coverage report only if the system being
             # tested matches the required environment.
-            if [ "${{PULP_VERSION}}" = "2.8" ] && [ "${{OS}}" != "rhel6" ]; then
+            if [ "$(echo -e \"2.8\n${{PULP_VERSION}}\" | sort -V | head -n 1)" = "2.8" ] && [ "${{OS}}" != "rhel6" ]; then
                 ansible-playbook --private-key pulp_server_key -i hosts ci/ansible/pulp_coverage.yaml \
                     -e pulp_coverage_action=report \
                     -e pulp_coverage_report_dir=/tmp \


### PR DESCRIPTION
Set the default version of Pulp to be installed by the Ansible Playbook to 2.9.
Deprecate Pulp 2.6 Automation jobs and add Pulp 2.9 Automation jobs.