### PR TITLE
Edit contents of Pulp Smash settings file

### DIFF
--- a/ci/ansible/roles/pulp-smash/templates/settings.j2
+++ b/ci/ansible/roles/pulp-smash/templates/settings.j2
@@ -1,5 +1,5 @@
 {
-    "default": {
+    "pulp": {
         "base_url": "{{ pulp_smash_baseurl }}",
         "auth": ["{{ pulp_smash_username }}", "{{ pulp_smash_password }}"],
         {% if pulp_smash_version %}

--- a/ci/jobs/pulp-dev.yaml
+++ b/ci/jobs/pulp-dev.yaml
@@ -168,7 +168,7 @@
             mkdir -p pulp_smash
             cat > pulp_smash/settings.json <<EOF
             {
-                "default": {
+                "pulp": {
                     "base_url": "${BASE_URL}",
                     "auth": ["admin", "admin"],
                     "version": "${PULP_VERSION}",


### PR DESCRIPTION
The Pulp Smash settings file now requires a section named "pulp",
instead of "default", like so:

```json
{"pulp": {
    "base_url": "http://pulp.example.com",
    "auth": ["admin", "admin"]
}}
```

See Pulp Smash commit 4e2e2b36007e4b307b058cbc34ea55a8d4c20c7c:
https://github.com/PulpQE/pulp-smash/commit/4e2e2b36007e4b307b058cbc34ea55a8d4c20c7c