### PR TITLE
Disable all repositories

### DIFF
--- a/ci/ansible/roles/pulp/tasks/main.yaml
+++ b/ci/ansible/roles/pulp/tasks/main.yaml
@@ -21,6 +21,10 @@
   shell: "subscription-manager subscribe --pool={{ rhn_poolid }}"
   when: ansible_distribution == "RedHat" and rhn_poolid is defined
 
+- name: Subscription Manager disable all repositories
+  shell: "subscription-manager repos --disable \"*\""
+  when: ansible_distribution == "RedHat"
+
 - name: Enable optional repository
   shell: "subscription-manager repos --enable rhel-{{ ansible_distribution_major_version }}-server-optional-rpms"
   when: ansible_distribution == "RedHat"


### PR DESCRIPTION
Disable all repositories to have more control on which repositories are enabled
on RHEL based systems.