### PR TITLE
Updates master config to use master branch for crane

### DIFF
--- a/ci/config/releases/master.yaml
+++ b/ci/config/releases/master.yaml
@@ -20,9 +20,8 @@ repositories:
     version: 2.1.0-0.1.beta
   - name: crane
     git_url: git@github.com:pulp/crane.git
-    git_branch: 2.0-release
-    parent_branch: master
-    version: 2.0.0-1
+    git_branch: master
+    version: 2.0.1-0.1beta
   - name: pulp_python
     git_url: git@github.com:pulp/pulp_python.git
     git_branch: master


### PR DESCRIPTION
Since it uses master the parent_branch can be removed. Also the
usage of master means the version is changing to 2.0.1-0.1beta

https://pulp.plan.io/issues/950
re #950