### PR TITLE
Install patch on pulp-fixtures-publisher job

### DIFF
--- a/ci/jobs/pulp-fixtures-publisher.yaml
+++ b/ci/jobs/pulp-fixtures-publisher.yaml
@@ -17,7 +17,7 @@
             user: '044c0620-d67e-4172-9814-dc49e443e7b6'
     builders:
         - shell: |
-            sudo dnf -y install createrepo make
+            sudo dnf -y install createrepo make patch
             make fixtures
             rsync -arvze "ssh -o StrictHostKeyChecking=no" --delete \
                 fixtures/* \


### PR DESCRIPTION
Make sure that the patch command is available when running make fixtures.