### PR TITLE
Use sudo to change selinux configuration

### DIFF
--- a/ci/nodepool/scripts/prepare_node.sh
+++ b/ci/nodepool/scripts/prepare_node.sh
@@ -46,7 +46,7 @@ elif  [ "${DISTRIBUTION}" == "fedora" ]; then
         # good solutions to this problem, the imminent release of f24 means that the simplest
         # solution is setting selinux to permissive on f22 until we stop supporting it in a
         # few weeks. Upstream issues and more details here: https://pulp.plan.io/issues/1904
-        sed -i -e 's/^SELINUX=.*/SELINUX=permissive/' /etc/sysconfig/selinux 
+        sudo sed -i -e 's/^SELINUX=.*/SELINUX=permissive/' /etc/sysconfig/selinux
     fi
 fi
 


### PR DESCRIPTION
When preparing the node, nodepool does not use the root user and because that
sudo should be used to make sure the edit selinux configuration.