### PR TITLE
Fix typo in bootstrap.sh script

### DIFF
--- a/ci/nodepool/nodepool.yaml
+++ b/ci/nodepool/nodepool.yaml
@@ -93,7 +93,7 @@ providers:
         private-key: /home/nodepool/.ssh/id_pulp_rsa
         min-ram: 3072
       - name: rhel5-np
-        base-image: RHEL-x86_64-5.10-20140827
+        base-image: rhel-5.11-server-x86_64-released
         user: jenkins
         setup: prepare_node.sh
         private-key: /home/nodepool/.ssh/id_pulp_rsa

--- a/ci/nodepool/scripts/bootstrap.sh
+++ b/ci/nodepool/scripts/bootstrap.sh
@@ -18,7 +18,7 @@ export PKG_MGR
 # Create the jenkins user in the jenkins group
 if  [ "${DISTRIBUTION}" == "redhat" ] && [ "${DISTRIBUTION_MAJOR_VERSION}" == "5" ]; then
     sudo useradd --create-home --home-dir /home/jenkins jenkins
-    cat scripts/jenkins-sudoers | sudo tee -a /etc/sudoers
+    cat jenkins-sudoers | sed -e "s/^%//" | sudo tee -a /etc/sudoers
 else
     sudo useradd --user-group --create-home --home-dir /home/jenkins jenkins
     sudo cp jenkins-sudoers "/etc/sudoers.d/00-jenkins"


### PR DESCRIPTION
Use the right pass to the jenkins-sudoers file in order to properly set up sudo
for the jenkins user on RHEL 5 slaves.

Also use an update RHEL 5 base image when building nodepool base images.