### PR TITLE
Add Jenkins jobs' ownership and email notification

### DIFF
--- a/ci/jobs/README.md
+++ b/ci/jobs/README.md
@@ -34,3 +34,24 @@ correspond to their project name, and therefore their yaml file name.
 
 When creating any new definition, please use a descriptive and accurate names so that you don't
 necessarily need, for example, to consult a macro definition to know what a macro does.
+
+Job template
+------------
+
+The job template `template.yaml.sample` can be used to create new job
+definitions. The template defines some required and minial set of options in
+order to conform with:
+
+* All jobs should have a owner.
+* All owners should receive an email if his/her jobs fail or are not built.
+* Before finishing the job the node should be marked offline in order to avoid
+  issues with Jenkins reusing a node that is about to be deleted by Nodepool.
+
+To start a new job from the template `cp` it into an YAML file:
+
+    cp template.yaml.sample my-job.yaml
+
+It is suggested to name the file as the name of the job if the new file will
+have just one job. Otherwise give the job a meaningful name that describes the
+set of jobs that will be defined on the file. Fore more information about job
+definition check the previous section.

--- a/ci/jobs/build-automation.yaml
+++ b/ci/jobs/build-automation.yaml
@@ -6,6 +6,8 @@
     name: 'build-automation-repo-{release_config}'
     defaults: ci-workflow-runtest
     node: 'rhel7-np'
+    properties:
+        - dev-ownership
     scm:
         - git:
             url: 'https://github.com/pulp/pulp_packaging.git'
@@ -69,5 +71,6 @@
             fi
     publishers:
       - irc-notify-all-summary
+      - email-notify-owners
       - mark-node-offline
 

--- a/ci/jobs/ci-update-jobs.yaml
+++ b/ci/jobs/ci-update-jobs.yaml
@@ -2,6 +2,8 @@
 - job:
     name: ci-update-jobs
     node: f23-np
+    properties:
+        - qe-ownership
     scm:
         - git:
             url: https://github.com/pulp/pulp_packaging.git
@@ -46,3 +48,6 @@
             jenkins-jobs --conf jenkins_jobs.ini update ci/jobs
 
             rm jenkins_jobs.ini
+    publishers:
+      - email-notify-owners
+      - mark-node-offline

--- a/ci/jobs/integration.yaml
+++ b/ci/jobs/integration.yaml
@@ -20,6 +20,7 @@
             - fc20-np
     # enable nodepool monitoring
     properties:
+      - dev-ownership
       - zeromq-event
     parameters:
         - string:
@@ -76,4 +77,5 @@
 
             cp -r test $WORKSPACE/test
     publishers:
+      - email-notify-owners
       - mark-node-offline

--- a/ci/jobs/macros.yaml
+++ b/ci/jobs/macros.yaml
@@ -5,6 +5,33 @@
 # they're easy to find.
 ###
 
+# Ownership that indicates bmbouter is the contact for the job
+- property:
+    name: bmbouter-ownership
+    properties:
+        - ownership:
+            owner: bmbouter
+
+# Ownership that indicates developers are the primary contact for the job
+- property:
+    name: dev-ownership
+    properties:
+        - ownership:
+            owner: semyers
+            co-owners:
+                - dkliban
+
+# Ownership that indicates quality engineers are the primary contact for the
+# job
+- property:
+    name: qe-ownership
+    properties:
+        - ownership:
+            owner: erezende
+            co-owners:
+                - jaudet
+                - pthomas
+
 # Used in the "ci-workflow-runtest" defaults definition.
 - publisher:
     name: default-ci-workflow-publishers
@@ -32,6 +59,17 @@
               matrix-trigger: only-configurations
               send-to:
                 - requester
+                - recipients
+
+# Notify job owners whenever the build is unstable or failed.
+- publisher:
+    name: email-notify-owners
+    publishers:
+        - email-ext:
+            failure: true
+            not-built: true
+            recipients: $JOB_COOWNERS_EMAILS # includes the owner
+            send-to:
                 - recipients
 
 # notify the default channel with a build summary on all build states (pass/unstable/fail)
@@ -112,4 +150,3 @@
             timeout: 30
             timeout-var: 'BUILD_TIMEOUT'
             fail: true
-

--- a/ci/jobs/pulp-dev.yaml
+++ b/ci/jobs/pulp-dev.yaml
@@ -1,6 +1,8 @@
 - job-template:
     name: 'pulp-{pulp_version}-dev-{os}'
     node: '{os}-vanilla-np'
+    properties:
+        - qe-ownership
     scm:
         - pulp-packaging-github
     wrappers:
@@ -117,9 +119,7 @@
         - archive:
             artifacts: "*.tar.gz"
             allow-empty: true
-        - email-ext:
-            recipients: $PULP_AUTOMATION_EMAIL_RECIPIENTS
-            attach-build-log: true
+        - email-notify-owners
         - irc-notify-all-summary
         - mark-node-offline
 
@@ -142,6 +142,8 @@
         - file:
             name: CA_CERT
             description: The CA certificate that signed the Pulp apache server.
+    properties:
+        - qe-ownership
     scm:
         - pulp-packaging-github
     builders:
@@ -184,4 +186,5 @@
     publishers:
         - archive:
             artifacts: 'pulp-smash/nose2-junit.xml'
+        - email-notify-owners
         - mark-node-offline

--- a/ci/jobs/pulp-fixtures-publisher.yaml
+++ b/ci/jobs/pulp-fixtures-publisher.yaml
@@ -4,6 +4,8 @@
 - job-template:
     name: 'pulp-fixtures-publisher'
     node: 'f23-docker-np'
+    properties:
+        - qe-ownership
     scm:
         - git:
             url: https://github.com/PulpQE/pulp-fixtures.git
@@ -23,4 +25,5 @@
                 fixtures/* \
                 pulpadmin@repos.fedorapeople.org:/srv/repos/pulp/pulp/fixtures
     publishers:
+      - email-notify-owners
       - mark-node-offline

--- a/ci/jobs/pulp-upgrade.yaml
+++ b/ci/jobs/pulp-upgrade.yaml
@@ -4,6 +4,8 @@
 - job-template:
     name: 'pulp-upgrade-{pulp_version}-{upgrade_pulp_version}-{os}'
     node: '{os}-vanilla-np'
+    properties:
+        - qe-ownership
     scm:
         - pulp-packaging-github
     wrappers:
@@ -147,6 +149,7 @@
                 sudo subscription-manager clean
             fi
     publishers:
+      - email-notify-owners
       - irc-notify-all-summary
       - mark-node-offline
 

--- a/ci/jobs/redmine.yaml
+++ b/ci/jobs/redmine.yaml
@@ -5,6 +5,8 @@
     name: 'redmine-bugzilla-automation'
     defaults: ci-workflow-runtest
     node: 'f23-np'
+    properties:
+        - dev-ownership
     scm:
         - git:
             url: 'https://github.com/pulp/pulp_packaging.git'
@@ -47,11 +49,5 @@
 
     publishers:
       # Take the node offline so that another build doesn't pile on
+      - email-notify-owners
       - mark-node-offline
-      - email-ext:
-          recipients: 'dkliban@redhat.com,bbouters@redhat.com,mhrivnak@redhat.com'
-          reply-to: $DEFAULT_REPLYTO
-          subject: 'Upstream/Downstream Linking Issues'
-          body: $DEFAULT_CONTENT
-          failure: false
-          first-failure: true

--- a/ci/jobs/template.yaml.sample
+++ b/ci/jobs/template.yaml.sample
@@ -1,0 +1,7 @@
+- job:
+    name: job-name
+    properties:
+        - {dev,qe,...}-ownership
+    publishers:
+        - email-notify-owners
+        - mark-node-offline

--- a/ci/jobs/unittests.yaml
+++ b/ci/jobs/unittests.yaml
@@ -23,9 +23,10 @@
             name: MATRIX_AXIS
     # enable nodepool monitoring
     properties:
-    - github:
-        url: https://github.com/pulp/pulp/
-    - zeromq-event
+      - dev-ownership
+      - github:
+          url: https://github.com/pulp/pulp/
+      - zeromq-event
     scm:
         - git:
             url: 'https://github.com/pulp/pulp.git'
@@ -300,6 +301,7 @@
           results: 'test/*.xml'
           keep-long-stdio: true
           test-stability: true
+      - email-notify-owners
       - mark-node-offline
 
 - job-group:


### PR DESCRIPTION
Create ownership macros and apply to each managed job, also add
email-notify-owners to each job that does not have an email sending publisher
configured in order to notify owners about failures and the job not being run.