### PR TITLE
Push the version bump commit on the branch where it took place.

### DIFF
--- a/ci/lib/promote.py
+++ b/ci/lib/promote.py
@@ -218,7 +218,7 @@ def merge_forward(git_directory, push=False, parent_branch=None):
         subprocess.check_call(['git', 'merge', '-s', 'ours', local_source_branch, '--no-edit'],
                               cwd=git_directory)
         if push:
-            subprocess.call(['git', 'push'], cwd=git_directory)
+            subprocess.call(['git', 'push', '-v'], cwd=git_directory)
 
     # Set the branch back tot he one we started on
     checkout_branch(git_directory, starting_branch)

--- a/ci/update-version-and-merge-forward.py
+++ b/ci/update-version-and-merge-forward.py
@@ -60,4 +60,7 @@ for component in get_components(configuration):
     subprocess.call(command, cwd=CI_DIR)
     command = ['git', 'commit', '-a', '-m', 'Bumping version to %s' % component['version']]
     subprocess.call(command, cwd=project_dir)
+    if push_to_github:
+        command = ['git', 'push', '-v']
+        subprocess.call(command, cwd=project_dir)
     promote.merge_forward(project_dir, push=push_to_github, parent_branch=parent_branch) 


### PR DESCRIPTION
Without this change, the update-version-and-merge-forward script
updates the version on e.g. 2.8-dev locally, doesn't push it, merges
2.8-dev to master, and then pushes master, requiring a manual push
of the 2.8-dev version bump commit. With this change, the 2.8-dev
version bump is pushed before being merged to master and pushed.