### PR TITLE
Add pulp_build on the Pulp Ansible role

### DIFF
--- a/ci/ansible/roles/pulp/defaults/main.yaml
+++ b/ci/ansible/roles/pulp/defaults/main.yaml
@@ -8,3 +8,6 @@ pulp_install_server: true
 
 # Pulp version to install
 pulp_version: 2.9
+
+# Pulp build to install, the choices are: beta, nightly and stable
+pulp_build: nightly

--- a/ci/ansible/roles/pulp/tasks/pulp_server.yaml
+++ b/ci/ansible/roles/pulp/tasks/pulp_server.yaml
@@ -21,7 +21,7 @@
 - name: Start and enable qpid-cpp server service
   service: name=qpidd state=started enabled=yes
 
-- name: Setup Pulp repository
+- name: Setup Pulp nightly repository
   template:
     src: yum_repo.j2
     dest: /etc/yum.repos.d/{{ item.key }}.repo
@@ -31,6 +31,18 @@
       baseurl: "https://repos.fedorapeople.org/pulp/pulp/testing/automation/{{ pulp_version }}/stage/{% if ansible_distribution == 'Fedora' %}fedora-{% endif %}$releasever/$basearch/"
 
       gpgcheck: 0
+  when: pulp_build == "nightly"
+
+- name: Setup Pulp beta or stable repository
+  template:
+    src: yum_repo.j2
+    dest: /etc/yum.repos.d/{{ item.key }}.repo
+  with_dict:
+    pulp:
+      name: Pulp Project repository
+      baseurl: "https://repos.fedorapeople.org/pulp/pulp/{{ pulp_build }}/{{ pulp_version }}/{% if ansible_distribution == 'Fedora' %}fedora-{% endif %}$releasever/$basearch/"
+      gpgcheck: 0
+  when: pulp_build == "beta" or pulp_build == "stable"
 
 - name: Install Pulp Server
   action: "{{ ansible_pkg_mgr }} name=@pulp-server-qpid"


### PR DESCRIPTION
The pulp_build indicates if is intended to install Pulp beta, nightly or stable
build.