### PR TITLE
Wraps pulp-dev permutations into single quotes

### DIFF
--- a/ci/jobs/projects.yaml
+++ b/ci/jobs/projects.yaml
@@ -32,14 +32,14 @@
 - project:
     name: pulp-dev
     os:
-        - f22
-        - f23
-        - rhel6
-        - rhel7
+        - 'f22'
+        - 'f23'
+        - 'rhel6'
+        - 'rhel7'
     pulp_version:
-        - 2.8
-        - 2.9
-        - 2.10:
+        - '2.8'
+        - '2.9'
+        - '2.10':
             reverse_trigger: 'master'
     reverse_trigger: '{pulp_version}-dev'
     jobs:


### PR DESCRIPTION
This makes jenkins-jobs-builder generate properly the permutations. For
example, for Pulp 2.10 it was generating 2.1 without the quotes.