### PR TITLE
Make pulp-smash-runner fail properly

### DIFF
--- a/ci/jobs/pulp-dev.yaml
+++ b/ci/jobs/pulp-dev.yaml
@@ -182,7 +182,10 @@
                 }
             }
             EOF
+            set +e
             XDG_CONFIG_DIRS=. nose2 -v --plugin nose2.plugins.junitxml -X --junit-xml pulp_smash.tests
+            set -e
+            test -f nose2-junit.xml
     publishers:
         - archive:
             artifacts: 'pulp-smash/nose2-junit.xml'


### PR DESCRIPTION
The test runner command returns a non-zero return code whenever at least one
failure happens and jenkins will understand that as being a failure, which will
then send an email to the owners.

In order to avoid the noise for test failures, make the pulp-smash-runner job
fail and notify owners if something serious happens.