### PR TITLE
Adds a docs builder Jenkins job

### DIFF
--- a/ci/docs-builder.py
+++ b/ci/docs-builder.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python2
+
+import argparse
+import subprocess
+import sys
+import os
+from shutil import copyfile
+
+import yaml
+
+from lib import builder
+from lib.builder import WORKING_DIR
+
+
+LATEST = '2.8'
+
+USERNAME = '57600fb10c1e664383000229'
+HOSTNAME = 'docs-pulp.rhcloud.com'
+
+SITE_ROOT = '~/app-root/repo/diy/'
+
+
+def get_components(configuration):
+    # Get the components from the yaml file
+    repos = configuration['repositories']
+    for component in repos:
+        yield component
+
+
+def load_config(config_name):
+    # Get the config
+    config_file = os.path.join(os.path.dirname(__file__),
+                               'config', 'releases', '%s.yaml' % config_name)
+    if not os.path.exists(config_file):
+        print "Error: %s not found. " % config_file
+        sys.exit(1)
+    with open(config_file, 'r') as config_handle:
+        config = yaml.safe_load(config_handle)
+    return config
+
+def main():
+    # Parse the args
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--release", required=True, help="Build the docs for a given release.")
+    opts = parser.parse_args()
+
+    configuration = load_config(opts.release)
+
+    # Get platform build version
+    repo_list = configuration['repositories']
+    try:
+        pulp_dict = filter(lambda x: x['name'] == 'pulp', repo_list)[0]
+    except IndexError:
+        raise RuntimeError("config file does not have an entry for 'pulp'")
+    version = pulp_dict['version']
+
+    if version.endswith('alpha'):
+        build_type = 'nightly'
+    elif version.endswith('beta'):
+        build_type = 'dev'
+    elif version.endswith('rc'):
+        build_type = 'dev'
+    else:
+        build_type = 'ga'
+
+    x_y_version = '.'.join(version.split('.')[:2])
+
+    builder.ensure_dir(WORKING_DIR, clean=True)
+
+    print "Getting git repos"
+    for component in get_components(configuration):
+        #clone the repos
+        branch_name = component['git_branch']
+        print "Cloning from github: %s" % component.get('git_url')
+        print "Switching to branch %s" % branch_name
+        clone_command = ['git', 'clone', component.get('git_url'), '--branch', branch_name]
+        exit_code = subprocess.call(clone_command, cwd=WORKING_DIR)
+        if exit_code != 0:
+            raise RuntimeError('An error occurred while cloning the repo.')
+
+    plugins_dir = os.sep.join([WORKING_DIR, 'pulp', 'docs', 'plugins'])
+    builder.ensure_dir(plugins_dir)
+
+    for component in get_components(configuration):
+        if component['name'] == 'pulp':
+            continue
+
+        src = os.sep.join([WORKING_DIR, component['name'], 'docs'])
+        dst = os.sep.join([plugins_dir, component['name']])
+        os.symlink(src, dst)
+
+    # copy in the pulp_index.rst file
+    if x_y_version == '2.8' and build_type == 'ga':
+        # This is a temporary codepath and should be removed when 2.8.5 is GA.
+        # On 2.8.5+ the installation index page was moved and the pulp_index_2_8.txt
+        # is the version that is compatible with 2.8.4 and earlier. Once 2.8.5 is GA
+        # this if statement branch and the pulp_index_2_8.rst file should be removed.
+        src_path = 'docs/pulp_index_2_8.rst'
+    else:
+        src_path = 'docs/pulp_index.rst'
+    pulp_index_rst = os.sep.join([WORKING_DIR, 'pulp', 'docs', 'index.rst'])
+    copyfile(src_path, pulp_index_rst)
+
+    # copy in the plugin_index.rst file
+    plugin_index_rst = os.sep.join([plugins_dir, 'index.rst'])
+    copyfile('docs/plugin_index.rst', plugin_index_rst)
+
+    # copy in the all_content_index.rst file
+    all_content_index_rst = os.sep.join([WORKING_DIR, 'pulp', 'docs', 'all_content_index.rst'])
+    copyfile('docs/all_content_index.rst', all_content_index_rst)
+
+    # build the docs via the Pulp project itself
+    print "Building the docs"
+    docs_directory = os.sep.join([WORKING_DIR, 'pulp', 'docs'])
+    make_command = ['make', 'html', 'SPHINXOPTS=-Wn']
+    exit_code = subprocess.call(make_command, cwd=docs_directory)
+    if exit_code != 0:
+        raise RuntimeError('An error occurred while building the docs.')
+
+    # rsync the docs to the root if it's GA of latest
+    if build_type == 'ga' and x_y_version == LATEST:
+        local_path_arg = os.sep.join([docs_directory, '_build', 'html']) + os.sep
+        remote_path_arg = '%s@%s:%s' % (USERNAME, HOSTNAME, SITE_ROOT)
+        rsync_command = ['rsync', '-avzh', '--delete', '--exclude', 'en', local_path_arg, remote_path_arg]
+        exit_code = subprocess.call(rsync_command, cwd=docs_directory)
+        if exit_code != 0:
+            raise RuntimeError('An error occurred while pushing docs to OpenShift.')
+
+    # rsync the docs to OpenShift
+    local_path_arg = os.sep.join([docs_directory, '_build', 'html']) + os.sep
+    remote_path_arg = '%s@%s:%sen/%s/' % (USERNAME, HOSTNAME, SITE_ROOT, x_y_version)
+    if build_type != 'ga':
+        remote_path_arg += build_type + '/'
+        path_option_arg = 'mkdir -p %sen/%s/%s/ && rsync' % (SITE_ROOT, x_y_version, build_type)
+        rsync_command = ['rsync', '-avzh', '--rsync-path', path_option_arg, '--delete', local_path_arg, remote_path_arg]
+    else:
+        path_option_arg = 'mkdir -p %sen/%s/ && rsync' % (SITE_ROOT, x_y_version)
+        rsync_command = ['rsync', '-avzh', '--rsync-path', path_option_arg, '--delete', '--exclude', 'nightly', '--exclude', 'dev', local_path_arg, remote_path_arg]
+    exit_code = subprocess.call(rsync_command, cwd=docs_directory)
+    if exit_code != 0:
+        raise RuntimeError('An error occurred while pushing docs to OpenShift.')
+
+    # rsync the robots.txt to OpenShift
+    local_path_arg = 'docs/robots.txt'
+    remote_path_arg = '%s@%s:%s' % (USERNAME, HOSTNAME, SITE_ROOT)
+    scp_command = ['scp', local_path_arg, remote_path_arg]
+    exit_code = subprocess.call(scp_command)
+    if exit_code != 0:
+        raise RuntimeError('An error occurred while pushing robots.txt to OpenShift.')
+
+    # rsync the testrubyserver.rb to OpenShift
+    local_path_arg = 'docs/testrubyserver.rb'
+    remote_path_arg = '%s@%s:%s' % (USERNAME, HOSTNAME, SITE_ROOT)
+    scp_command = ['scp', local_path_arg, remote_path_arg]
+    exit_code = subprocess.call(scp_command)
+    if exit_code != 0:
+        raise RuntimeError('An error occurred while pushing testrubyserver.rb to OpenShift.')
+
+    # add symlink for latest
+    symlink_cmd = [
+        'ssh',
+        '%s@%s' % (USERNAME, HOSTNAME),
+        'ln -sfn %sen/%s %sen/latest' % (SITE_ROOT, LATEST, SITE_ROOT)
+    ]
+    exit_code = subprocess.call(symlink_cmd)
+    if exit_code != 0:
+        raise RuntimeError("An error occurred while creating the 'latest' symlink testrubyserver.rb to OpenShift.")
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/docs/all_content_index.rst
+++ b/ci/docs/all_content_index.rst
@@ -1,0 +1,13 @@
+Documentation Index
+===================
+
+.. toctree::
+
+   user-guide/index
+   dev-guide/index
+   plugins/pulp_rpm/index
+   plugins/pulp_python/index
+   plugins/pulp_puppet/index
+   plugins/pulp_docker/index
+   plugins/pulp_ostree/index
+   plugins/crane/index

--- a/ci/docs/plugin_index.rst
+++ b/ci/docs/plugin_index.rst
@@ -1,0 +1,81 @@
+Plugins
+=======
+
+Pulp supports the following plugin types:
+
+
+.. _rpm_list_desc:
+
+RPM
+---
+
+Host your own RPM repositories. You can sync content from remote repositories, or upload your own
+packages. You can manage RPM, SRPM, DRPM, Errata, and other RPM related package types along with
+their metadata.
+
+- :doc:`pulp_rpm/user-guide/installation`
+- :doc:`Quick Start Guide <pulp_rpm/user-guide/quick-start>`
+- :doc:`pulp_rpm/user-guide/index`
+- :doc:`pulp_rpm/tech-reference/index`
+- `RPM Plugin Bugs <https://pulp.plan.io/projects/pulp_rpm/issues?sort=cf_5%3Adesc%2Cid%3Adesc>`_
+
+
+.. _python_list_desc:
+
+Python
+------
+
+Host your own Python repositories, fetch packages from PyPI, or upload your own Python packages.
+
+
+- :doc:`pulp_python/admin-docs/installation`
+- :doc:`pulp_python/user-docs/getting_started`
+- :doc:`pulp_python/admin-docs/index`
+- :doc:`pulp_python/user-docs/index`
+- :doc:`pulp_python/reference/index`
+- `Python Plugin Bugs <https://pulp.plan.io/projects/pulp_python/issues?sort=cf_5%3Adesc%2Cid%3Adesc>`_
+
+
+.. _puppet_list_desc:
+
+Puppet
+------
+
+Host your own Puppet repositories, fetch from puppetforge, or upload your own Puppet modules.
+
+- :doc:`pulp_puppet/user-guide/installation`
+- :doc:`Quick Start Guide <pulp_puppet/user-guide/quick-start>`
+- :doc:`pulp_puppet/user-guide/index`
+- :doc:`pulp_puppet/tech-reference/index`
+- `Puppet Plugin Bugs <https://pulp.plan.io/projects/pulp_puppet/issues?sort=cf_5%3Adesc%2Cid%3Adesc>`_
+
+
+.. _docker_list_desc:
+
+Docker
+------
+
+Fetch from Docker Hub and compose your own Docker repositories.
+
+To operate a Docker registry, you will also need :doc:`Crane <crane/index>` to serve the Docker
+files Pulp publishes.
+
+- :doc:`pulp_docker/user-guide/installation`
+- :doc:`pulp_docker/user-guide/recipes`
+- :doc:`pulp_docker/user-guide/index`
+- :doc:`pulp_docker/tech-reference/index`
+- `Docker Plugin Bugs <https://pulp.plan.io/projects/pulp_docker/issues?sort=cf_5%3Adesc%2Cid%3Adesc>`_
+
+
+.. _ostree_list_desc:
+
+OSTree
+------
+
+Host OSTree repositories, fetch from remote OSTree repositories, or upload OSTree images.
+
+- :doc:`pulp_ostree/user-guide/installation`
+- :doc:`pulp_ostree/user-guide/recipes`
+- :doc:`pulp_ostree/user-guide/index`
+- :doc:`pulp_ostree/tech-reference/index`
+- `OSTree Plugin Bugs <https://pulp.plan.io/projects/pulp_ostree/issues?sort=cf_5%3Adesc%2Cid%3Adesc>`_

--- a/ci/docs/pulp_index.rst
+++ b/ci/docs/pulp_index.rst
@@ -1,0 +1,42 @@
+.. _pulp_documentation:
+
+Pulp
+====
+
+Pulp manages repositories of content, such as software packages, and makes it available for
+installation. Pulp has plugins for :ref:`rpm_list_desc`, :ref:`python_list_desc`,
+:ref:`puppet_list_desc`, :ref:`docker_list_desc`, and :ref:`ostree_list_desc`.
+
+Using Pulp you can:
+
+* locally mirror all or part of a repository
+* host your own content in a new repository
+* manage content from multiple sources in one place
+* Promote content through different repos in an organized way
+
+Pulp has a :doc:`REST API <dev-guide/integration/index>` and command line interface for management.
+
+Pulp is completely free and open-source!
+
+Content
+=======
+
+.. toctree::
+   :maxdepth: 1
+
+   user-guide/installation/index
+   user-guide/index
+   plugins/index
+   dev-guide/index
+   dev-guide/contributing/index
+
+
+Index and Search
+================
+
+* :ref:`search`
+
+.. toctree::
+   :maxdepth: 1
+
+   all_content_index

--- a/ci/docs/pulp_index_2_8.rst
+++ b/ci/docs/pulp_index_2_8.rst
@@ -1,0 +1,42 @@
+.. _pulp_documentation:
+
+Pulp
+====
+
+Pulp manages repositories of content, such as software packages, and makes it available for
+installation. Pulp has plugins for :ref:`rpm_list_desc`, :ref:`python_list_desc`,
+:ref:`puppet_list_desc`, :ref:`docker_list_desc`, and :ref:`ostree_list_desc`.
+
+Using Pulp you can:
+
+* locally mirror all or part of a repository
+* host your own content in a new repository
+* manage content from multiple sources in one place
+* Promote content through different repos in an organized way
+
+Pulp has a :doc:`REST API <dev-guide/integration/index>` and command line interface for management.
+
+Pulp is completely free and open-source!
+
+Content
+=======
+
+.. toctree::
+   :maxdepth: 1
+
+   user-guide/installation
+   user-guide/index
+   plugins/index
+   dev-guide/index
+   dev-guide/contributing/index
+
+
+Index and Search
+================
+
+* :ref:`search`
+
+.. toctree::
+   :maxdepth: 1
+
+   all_content_index

--- a/ci/docs/testrubyserver.rb
+++ b/ci/docs/testrubyserver.rb
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+require 'webrick'
+include WEBrick
+
+config = {}
+config.update(:Port => 8080)
+config.update(:BindAddress => ARGV[0])
+config.update(:DocumentRoot => ARGV[1])
+server = HTTPServer.new(config)
+['INT', 'TERM'].each {|signal|
+  trap(signal) {server.shutdown}
+}
+
+server.start

--- a/ci/jobs/docs.yaml
+++ b/ci/jobs/docs.yaml
@@ -1,0 +1,69 @@
+# This set of Jenkins jobs creates an installs all the
+# necessary tools to build a repository with the help of Koji, then publishes
+# the results.
+
+- project:
+    name: docs-builder
+    jobs:
+     - 'docs-builder-{release_config}'
+    release_config:
+     - 2.8-build
+     - 2.8-dev
+     - 2.8-release
+     - 2.9-build
+     - 2.9-dev
+     - master
+- job-template:
+    name: 'docs-builder-{release_config}'
+    defaults: ci-workflow-runtest
+    node: 'f23-np'
+    properties:
+        - docs-ownership
+    scm:
+        - git:
+            url: 'https://github.com/pulp/pulp_packaging.git'
+            branches:
+                - origin/master
+            basedir: pulp_packaging
+            skip-tag: true
+            wipe-workspace: false
+    triggers:
+        - timed: "@midnight"
+    wrappers:
+        - ssh-agent-credentials:
+            users:
+                - '044c0620-d67e-4172-9814-dc49e443e7b6'
+                - '2f7a0c14-d520-40d3-b9b5-ebd8bb780d03'
+        - credentials-binding:
+            - zip-file:
+                credential-id: 9051da21-c8af-49bd-a0ac-c1dd94a6d216
+                variable: KOJI_CONFIG
+        - timeout:
+            # Timeout in minutes
+            timeout: 240
+            timeout-var: 'BUILD_TIMEOUT'
+            fail: true
+    builders:
+        - shell: |
+            #!/bin/bash
+
+            sudo dnf install graphviz plantuml python-sphinx PyYAML python-sphinx_rtd_theme -y
+
+            git config --global user.email "pulp-infra@redhat.com"
+            git config --global user.name "pulpbot"
+            git config --global push.default simple
+            set -x
+
+            # Add github.com as a known host
+            echo "github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==" >> /home/jenkins/.ssh/known_hosts
+            echo "docs-pulp.rhcloud.com,52.1.83.65 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAwUPkUQ84FKIWhOxy5RBBuR9gbrov2epARmFmaxD7NFRayobnDvl8GaBTbH1kxaZ/tYQeIqVE1assL74KArMQBzz6rj0FEWf0zrXxAY55EGswmWEEdqlYu1LbIxDCG6opqkiq6ocxjea9K3XYq+2aYoAvI3sshSImTYZP1glFhrh3QUsNJHOfDboTLJFNSdLjzXubRMa4eEx7s9pe9kwBOaLNIiVeGzUWg5+KaykSg2UMB3aG127t8kX+OhDYceVR42ehQJ0MjQGlGoNtldxGrlX8NjxUqvJAo6pqNqRK8Cps7/x/m0GPXWAgSZymhurXmj1o2LP5nKLtVzMPvwMb0w==" >> /home/jenkins/.ssh/known_hosts
+
+            chmod 644 /home/jenkins/.ssh/known_hosts
+
+            # clone and build the docs
+            cd pulp_packaging/ci/
+            export PYTHONUNBUFFERED=1
+            python docs-builder.py --release {release_config}
+    publishers:
+      - email-notify-owners
+      - mark-node-offline

--- a/ci/jobs/macros.yaml
+++ b/ci/jobs/macros.yaml
@@ -20,7 +20,7 @@
     name: docs-ownership
     properties:
         - ownership:
-            owner: bmbouter
+            owner: bbouters
             co-owners:
                 - ttereshc
 


### PR DESCRIPTION
This job nightly build one sphinx project which includes
platform and all plugins develped by the core dev team.

This job uses the docs-ownership so it has owners. It also
uses the e-mail notify macro for owner notification on
failure.

The version of each plugin is specified in the releases yaml
files used by the build infrastructure. Each repo is cloned
freshly with each build.

This job comes with additional rst files which are merged in
prior to the build. This additional content organizes all of
the other content which was not designed to be shown as one
site.

It also deploys a robots.txt for the root of the docs site.

https://pulp.plan.io/issues/950
re #950