### PR TITLE
fix deprecations and cobertura type problems

### DIFF
--- a/ci/jobs/build-automation.yaml
+++ b/ci/jobs/build-automation.yaml
@@ -25,8 +25,7 @@
           description: "Perform a release build, defaults to 'false'."
       - python-unbuffered
     wrappers:
-        - ssh-agent-credentials:
-            user: '044c0620-d67e-4172-9814-dc49e443e7b6'
+        - jenkins-ssh-credentials
         - credentials-binding:
             - zip-file:
                 credential-id: 9051da21-c8af-49bd-a0ac-c1dd94a6d216
@@ -103,8 +102,7 @@
             skip-tag: true
             wipe-workspace: false
     wrappers:
-        - ssh-agent-credentials:
-            user: '044c0620-d67e-4172-9814-dc49e443e7b6'
+        - jenkins-ssh-credentials
         - timeout:
             # Timeout in minutes
             timeout: 240
@@ -121,9 +119,10 @@
     publishers:
       # - mark-node-offline is omitted: you can't have more than one groovy postbuild step, and
       #   groovy is used here to mark the build as unstable when promotion is blocked
-      - groovy-postbuild: |
-          manager.build.getBuiltOn().toComputer().setTemporarilyOffline(true)
-          if(manager.logContains(".*Promotion blocked.*")) {{ manager.buildUnstable() }}
+      - groovy-postbuild:
+          script: |
+            manager.build.getBuiltOn().toComputer().setTemporarilyOffline(true)
+            if(manager.logContains(".*Promotion blocked.*")) {{ manager.buildUnstable() }}
       - irc-notify-all-summary
       # - email-notify-owners
       # don't notify owners until #2022 is fixed

--- a/ci/jobs/macros.yaml
+++ b/ci/jobs/macros.yaml
@@ -122,7 +122,8 @@
 - publisher:
     name: mark-node-offline
     publishers:
-      - groovy-postbuild: "manager.build.getBuiltOn().toComputer().setTemporarilyOffline(true)"
+      - groovy-postbuild:
+          script: "manager.build.getBuiltOn().toComputer().setTemporarilyOffline(true)"
 
 - scm:
     name: pulp-packaging-github
@@ -153,7 +154,6 @@
                 variable: KOJI_CONFIG
         - default-ci-workflow-build-timeout-wrapper
 
-
 - wrapper:
     name: default-ci-workflow-build-timeout-wrapper
     wrappers:
@@ -162,3 +162,10 @@
             timeout: 30
             timeout-var: 'BUILD_TIMEOUT'
             fail: true
+
+- wrapper:
+    name: jenkins-ssh-credentials
+    wrappers:
+        - ssh-agent-credentials:
+            users:
+                - '044c0620-d67e-4172-9814-dc49e443e7b6'

--- a/ci/jobs/projects.yaml
+++ b/ci/jobs/projects.yaml
@@ -108,7 +108,7 @@
             - f23-np
             - rhel7-np
       - pulp_puppet:
-          min_coverage: 95.0
+          min_coverage: 95
           unittest_branches:
             - 2.8-dev
             - 2.9-dev
@@ -131,7 +131,7 @@
             - rhel6-np
             - rhel7-np
       - pulp_rpm:
-          min_coverage: 87.0
+          min_coverage: 87
           unittest_branches:
             - 2.8-dev
             - 2.9-dev

--- a/ci/jobs/pulp-fixtures-publisher.yaml
+++ b/ci/jobs/pulp-fixtures-publisher.yaml
@@ -15,8 +15,7 @@
     triggers:
         - timed: '@midnight'
     wrappers:
-        - ssh-agent-credentials:
-            user: '044c0620-d67e-4172-9814-dc49e443e7b6'
+        - jenkins-ssh-credentials
     builders:
         - shell: |
             sudo dnf -y install createrepo make patch

--- a/ci/jobs/pulp-installer.yaml
+++ b/ci/jobs/pulp-installer.yaml
@@ -44,8 +44,7 @@
             files:
                 - file-id: rhn_credentials
                   variable: RHN_CREDENTIALS
-        - ssh-agent-credentials:
-            user: '044c0620-d67e-4172-9814-dc49e443e7b6'
+        - jenkins-ssh-credentials
     builders:
         - shell: |
             sudo yum install -y ansible


### PR DESCRIPTION
The cobertura plugin wants ints, not floats, for coverage values. This was
causing the "Error in request. Possibly authentication failed [500]: Server Error"
errors that we've been seeing.

groovy-postbuild was changed to want the groovy script in a "script"
dict config key, so I did that where needed to make that deprecation
warning go away

ssh-agent-credentials wants an array of users instead of a single user
param now in its config dict, so I've updated jobs using that wrapper
to be configured the new way. This has also become a macro, because
if I'm going to fix it the same way in four places I might as well
make it a macro.