### PR TITLE
Add upgrade jobs for Pulp 2.7 stable to 2.8 beta

### DIFF
--- a/ci/jobs/projects.yaml
+++ b/ci/jobs/projects.yaml
@@ -61,7 +61,13 @@
         - 2.7-stable
         - 2.8-stable
     upgrade_pulp_version:
+        - 2.8-beta
         - 2.8-nightly
+    exclude:
+        - os: f23
+          pulp_version: 2.7-stable
+        - pulp_version: 2.8-stable
+          upgrade_pulp_version: 2.8-beta
     jobs:
         - 'pulp-upgrade-{pulp_version}-{upgrade_pulp_version}-trigger'
         - 'pulp-upgrade-{pulp_version}-{upgrade_pulp_version}-{os}'


### PR DESCRIPTION
Also exclude unwanted permutations like Pulp 2.7 stable on Fedora 23 because
there are no packages released also upgrade from Pulp 2.8 stable to 2.9 beta.