### PR TITLE
Causes some doc builders to not build nightly

### DIFF
--- a/ci/jobs/docs.yaml
+++ b/ci/jobs/docs.yaml
@@ -1,6 +1,5 @@
-# This set of Jenkins jobs creates an installs all the
-# necessary tools to build a repository with the help of Koji, then publishes
-# the results.
+# This set of Jenkins jobs which build the Pulp platform and plugin documentation and publishes
+# it to https://docs.pulpproject.org/
 
 - job-template:
     name: 'docs-builder-{release_config}'
@@ -17,7 +16,7 @@
             skip-tag: true
             wipe-workspace: false
     triggers:
-        - timed: "@midnight"
+        - timed: '{trigger_times}'
     wrappers:
         - ssh-agent-credentials:
             users:

--- a/ci/jobs/projects.yaml
+++ b/ci/jobs/projects.yaml
@@ -25,16 +25,24 @@
      - ci-update-jobs
 
 - project:
-    name: docs
+    name: docs-build-nightly
+    jobs:
+     - 'docs-builder-{release_config}'
+    release_config:
+     - 2.8-dev
+     - 2.9-dev
+     - master
+    trigger_times: '@midnight'
+
+- project:
+    name: docs-build-manually
     jobs:
      - 'docs-builder-{release_config}'
     release_config:
      - 2.8-build
-     - 2.8-dev
      - 2.8-release
      - 2.9-build
-     - 2.9-dev
-     - master
+    trigger_times: ''
 
 - project:
     name: pulp-dev


### PR DESCRIPTION
Previously there was only one project definition for doc builders,
but now there are two. Any job defined by the 'docs-build-nightly'
project will run at midnight. Any job defined by the
'docs-build-manually' project requires manual triggering.