### PR TITLE
Add more upgrade jobs

### DIFF
--- a/ci/jobs/projects.yaml
+++ b/ci/jobs/projects.yaml
@@ -81,13 +81,11 @@
         - 2.7-stable
         - 2.8-stable
     upgrade_pulp_version:
-        - 2.8-beta
         - 2.8-nightly
+        - 2.9-beta
     exclude:
         - os: f23
           pulp_version: 2.7-stable
-        - pulp_version: 2.8-stable
-          upgrade_pulp_version: 2.8-beta
     jobs:
         - 'pulp-upgrade-{pulp_version}-{upgrade_pulp_version}-trigger'
         - 'pulp-upgrade-{pulp_version}-{upgrade_pulp_version}-{os}'


### PR DESCRIPTION
Add jobs for testing Pulp upgrade:

* from 2.7-stable to 2.9-beta
* from 2.8-stable to 2.9-beta

And drop jobs for testing Pulp upgrade from 2.7-stable to 2.8-beta.