### PR TITLE
Add task to pulp for subscription manager to register by activation-key.

### DIFF
--- a/ci/ansible/roles/pulp/tasks/main.yaml
+++ b/ci/ansible/roles/pulp/tasks/main.yaml
@@ -15,7 +15,16 @@
 
 - name: Subscription Manager register
   shell: "subscription-manager register --force --user={{ rhn_username }} --password={{ rhn_password }}"
-  when: ansible_distribution == "RedHat" and rhn_username is defined and rhn_password is defined
+  when: ansible_distribution == "RedHat" and rhn_username is defined and rhn_password is defined and
+        rhn_activation_key is undefined and rhn_organization is undefined
+
+- name: Subscription Manager register by Activation Key
+  shell: >
+        subscription-manager register --force
+        --activationkey={{ rhn_activation_key }}
+        --org={{ rhn_organization }}
+  when: ansible_distribution == "RedHat" and
+        rhn_activation_key is defined and rhn_organization is defined
 
 - name: Subscription Manager subscribe
   shell: "subscription-manager subscribe --pool={{ rhn_poolid }}"


### PR DESCRIPTION
Add a new task for subscription manager to register by activation-key.

(1) When running: `ansible-playbook -e rhn_username=user -e rhn_password=pass playbook.yaml`
Just the Subscription Manager register by username and password should run

(2) When running: `ansible-playbook -e rhn_activation_key=ak -e rhn_organization=org playbook.yaml`
Just the Subscription Manager register by activation key and organization should run

Test output:

```
$ ansible-playbook pulp_server.yaml --u vagrant -i ~/ansible-hosts -k \
    -e rhn_username=user -e rhn_password=pass --check
TASK [pulp : Subscription Manager register] ************************************
skipping: [192.168.121.120]

TASK [pulp : Subscription Manager register by Activation Key] ******************
skipping: [192.168.121.120]
```

```
$ ansible-playbook pulp_server.yaml --u vagrant -i ~/ansible-hosts -k \
    -e rhn_activation_key=ak1 -e rhn_organization=Default_Organization --check
TASK [pulp : Subscription Manager register] ************************************
skipping: [192.168.121.120]

TASK [pulp : Subscription Manager register by Activation Key] ******************
skipping: [192.168.121.120]

```