### PR TITLE
Fix up version so we promote '2.10', not '2.1'

### DIFF
--- a/ci/jobs/projects.yaml
+++ b/ci/jobs/projects.yaml
@@ -13,11 +13,11 @@
      - 'build-automation-promote-{release_config}'
     release_config:
       - 2.8-dev:
-         version: 2.8
+         version: '2.8'
       - 2.9-dev:
-         version: 2.9
+         version: '2.9'
       - master:
-         version: 2.10
+         version: '2.10'
 
 - project:
     name: ci-update-jobs


### PR DESCRIPTION
Versions need to be strings, not floats, to keep the trailing zero