### PR TITLE
build-all can skip scratch for release builds, promote regex fix

### DIFF
--- a/ci/lib/promote.py
+++ b/ci/lib/promote.py
@@ -45,7 +45,7 @@ def get_promotion_chain(git_directory, git_branch, upstream_name='origin', paren
         return ['master']
 
     # parse the git_branch: x.y-(dev|testing|release)
-    branch_regex = "(\d+.\d+)-(dev|testing|release)"
+    branch_regex = "(\d+.\d+)-(dev|testing|release)$"
     match = re.search(branch_regex, git_branch)
     source_branch_version = match.group(1)
     source_branch_stream = match.group(2)


### PR DESCRIPTION
- My release process includes a manual scratch build step, so doing a
  scratch build in the release step is redundant. Note that the scratch
  build can only be skipped for a release build. (build-all.py)
- A regex in lib/promote.py was unanchored, and inappropriately
  interpreting '2.9.0-releasenotes' as '9.0-release'. A terminal
  string anchor fixes this issue.