### PR TITLE
Triage log syncing + projects tweak

### DIFF
--- a/ci/jobs/projects.yaml
+++ b/ci/jobs/projects.yaml
@@ -97,6 +97,11 @@
      - redmine-bugzilla-automation
 
 - project:
+    name: sync
+    jobs:
+     - sync-triage-logs
+
+- project:
     name: unittests
     jobs:
      - 'unittest-pulp-pr'

--- a/ci/jobs/projects.yaml
+++ b/ci/jobs/projects.yaml
@@ -2,14 +2,6 @@
     name: build-automation
     jobs:
      - 'build-automation-repo-{release_config}'
-    release_config:
-     - 2.8-dev
-     - 2.9-dev
-     - master
-
-- project:
-    name: build-automation-promote
-    jobs:
      - 'build-automation-promote-{release_config}'
     release_config:
       - 2.8-dev:

--- a/ci/jobs/sync.yaml
+++ b/ci/jobs/sync.yaml
@@ -1,0 +1,18 @@
+- job:
+    name: sync-triage-logs
+    triggers:
+      # ideally, should trigger this with an event from the triage bot
+      # for now we'll fire it nightly and after triage is supposed to end
+      - timed: |
+          @nightly
+          31 11 * * 2,5
+    wrappers:
+      - jenkins-ssh-credentials
+    builders:
+      # requires ssh access to the box running supybot using the jenkins ssh key
+      # to download the meeting logs prior to uploading them to repos.fedorapeople
+      - shell: |
+          rm -rf *
+          rsync -rv jenkins@10.8.180.47:/srv/supybot/meetings/pulp-dev/ pulp_dev
+          rsync -rv pulp_dev/ pulpadmin@repos.fedorapeople.org:public_html/triage
+    # One of the few jobs that can run on the jenkins master, no need to mark offline


### PR DESCRIPTION
Ideas separated into two commits:
- triage log sync job
- consolidate build-automation jobs under one project