### PR TITLE
Correctly compare Pulp version strings

### DIFF
--- a/ci/ansible/pulp_server.yaml
+++ b/ci/ansible/pulp_server.yaml
@@ -5,6 +5,6 @@
     - role: pulp
       pulp_install_server: true
     - role: lazy
-      when: pulp_version|float >= 2.8
+      when: pulp_version | version_compare('2.8', '>=')
     - role: pulp-certs
   sudo: true


### PR DESCRIPTION
When comparing two version strings, it's invalid to do this:

    version | float >= 2.8

The problem is that `version` may be a value such as '2.10', which is
cast to the float value of 2.1. The `version_compare` filter should be
used instead.

Thanks to @elyezer for help with tracking down this issue.

Fix: https://pulp.plan.io/issues/2080