### PR TITLE
Make pulp-fixtures-publisher job install rpm-sign

### DIFF
--- a/ci/jobs/pulp-fixtures-publisher.yaml
+++ b/ci/jobs/pulp-fixtures-publisher.yaml
@@ -18,7 +18,7 @@
         - jenkins-ssh-credentials
     builders:
         - shell: |
-            sudo dnf -y install createrepo make patch
+            sudo dnf -y install createrepo make patch rpm-sign
             make fixtures
             rsync -arvze "ssh -o StrictHostKeyChecking=no" --delete \
                 fixtures/* \


### PR DESCRIPTION
This change allows the pulp-fixtures-publisher job to support the
fixtures added by https://github.com/PulpQE/pulp-fixtures/pull/17.