### PR TITLE
MentionBot config blacklist

### DIFF
--- a/.mention-bot
+++ b/.mention-bot
@@ -1,0 +1,13 @@
+{
+    "userBlacklist": [
+        "barnabycourt",
+        "beav",
+        "bowlofeggs",
+        "jdob",
+        "jlconnor",
+        "jwmatthews",
+        "mccun943",
+        "pkilambi",
+        "slagle"
+    ]
+}


### PR DESCRIPTION
Generally blacklists folks that have moved to other teams