### PR TITLE
Move pulp-upgrade jobs trigger

### DIFF
--- a/ci/jobs/projects.yaml
+++ b/ci/jobs/projects.yaml
@@ -82,7 +82,6 @@
         - os: f23
           pulp_version: 2.7-stable
     jobs:
-        - 'pulp-upgrade-{pulp_version}-{upgrade_pulp_version}-trigger'
         - 'pulp-upgrade-{pulp_version}-{upgrade_pulp_version}-{os}'
 
 - project:

--- a/ci/jobs/pulp-upgrade.yaml
+++ b/ci/jobs/pulp-upgrade.yaml
@@ -8,6 +8,8 @@
         - qe-ownership
     scm:
         - pulp-packaging-github
+    triggers:
+        - timed: '@weekly'
     wrappers:
         - ansicolor
         - config-file-provider:
@@ -208,18 +210,3 @@
       - email-notify-owners
       - irc-notify-all-summary
       - mark-node-offline
-
-
-# Job that triggers the upgrade jobs
-
-- job-template:
-    name: 'pulp-upgrade-{pulp_version}-{upgrade_pulp_version}-trigger'
-    triggers:
-        - timed: '@weekly'
-    builders:
-        - trigger-builds:
-            - project:
-                - 'pulp-upgrade-{pulp_version}-{upgrade_pulp_version}-f22'
-                - 'pulp-upgrade-{pulp_version}-{upgrade_pulp_version}-f23'
-                - 'pulp-upgrade-{pulp_version}-{upgrade_pulp_version}-rhel6'
-                - 'pulp-upgrade-{pulp_version}-{upgrade_pulp_version}-rhel7'


### PR DESCRIPTION
Move the weekly trigger to each upgrade job since there are some permutations
that are not valid, like Pulp 2.7 on Fedora 23, and that makes the separated
trigger job to fail.