### PR TITLE
Add more upgrade jobs

### DIFF
--- a/ci/jobs/projects.yaml
+++ b/ci/jobs/projects.yaml
@@ -81,6 +81,8 @@
         - 2.8-beta
         - 2.8-nightly
         - 2.9-beta
+        - 2.9-nightly
+        - 2.10-beta
     exclude:
         - os: f23
           pulp_version: 2.7-stable


### PR DESCRIPTION
Add upgrade jobs to check upgrades to Pulp 2.9 nightly and 2.10 beta.