### PR TITLE
Build 3.0-dev docs nightly

### DIFF
--- a/ci/config/releases/3.0-dev.yaml
+++ b/ci/config/releases/3.0-dev.yaml
@@ -22,10 +22,6 @@ repositories:
     git_url: git@github.com:pulp/pulp_docker.git
     git_branch: 3.0-dev
     version: 3.0.0-0.0.alpha
-  - name: crane
-    git_url: git@github.com:pulp/crane.git
-    git_branch: 3.0-dev
-    version: 3.0.0-0.0.alpha
   - name: pulp_ostree
     git_url: git@github.com:pulp/pulp_ostree.git
     git_branch: 3.0-dev
@@ -34,3 +30,8 @@ repositories:
     git_url: git@github.com:pulp/pulp_python.git
     git_branch: 3.0-dev
     version: 3.0.0-0.0.alpha
+# crane isn't on the cool 3.0-dev boat
+  - name: crane
+    git_url: git@github.com:pulp/crane.git
+    git_branch: master
+    version: 2.1.0-0.1.alpha

--- a/ci/jobs/projects.yaml
+++ b/ci/jobs/projects.yaml
@@ -27,6 +27,7 @@
      - 2.9-dev
      - 2.10-dev
      - master
+     - 3.0-dev
     trigger_times: '@midnight'
 
 - project:


### PR DESCRIPTION
Since we'll most definitely be making docs changes as part of 3.0-dev,
it seems like a good idea to get the 3.0 nightly builds started up.