### PR TITLE
pulp-smash runner uses python 3 explicitly

### DIFF
--- a/ci/jobs/pulp-dev.yaml
+++ b/ci/jobs/pulp-dev.yaml
@@ -163,7 +163,7 @@
             sudo update-ca-trust
 
             sudo yum -y install python-pip python-virtualenv
-            virtualenv venv
+            virtualenv -p /usr/bin/python3 venv
             source venv/bin/activate
             git clone http://github.com/PulpQE/pulp-smash.git
             cd pulp-smash


### PR DESCRIPTION
It was previously using python 2, which no longer works.