### PR TITLE
Upgrade logs

### DIFF
--- a/ci/jobs/macros.yaml
+++ b/ci/jobs/macros.yaml
@@ -5,6 +5,27 @@
 # they're easy to find.
 ###
 
+# Capture system, httpd and squid logs into logs directory. Also create a
+# tarball called logs.tar.gz of the logs.
+- builder:
+    name: capture-logs
+    builders:
+        - shell: |
+            rm -rf logs
+            mkdir logs
+            if [ "$(which journalctl 2>/dev/null)" ]; then
+                sudo journalctl > logs/syslog
+            elif [ -f /var/log/messages ]; then
+                sudo cat /var/log/messages > logs/syslog
+            else
+                echo "Failed to get syslogs: neither journalctl nor " \
+                "/var/log/messages were found." > logs/syslogs
+            fi
+            [ -e /var/log/httpd ] && sudo cp -R /var/log/httpd logs
+            [ -e /var/log/squid ] && sudo cp -R /var/log/squid logs
+            sudo chown -R "${{USER}}":"${{USER}}" logs
+            tar -zcf logs.tar.gz logs
+
 # Inject the PYTHONUNBUFFERED env var into builds using a parameter. This needs to be a string
 # param, not a bool, because any value turns on unbuffered mode, including "false".
 - parameter:

--- a/ci/jobs/pulp-dev.yaml
+++ b/ci/jobs/pulp-dev.yaml
@@ -87,21 +87,7 @@
         #     steps:
         #         - sonar:
         #             sonar-name: 'Sonar Test Server'
-        - shell: |
-            rm -rf logs
-            mkdir logs
-            if [ "$(which journalctl 2>/dev/null)" ]; then
-                sudo journalctl > logs/syslog
-            elif [ -f /var/log/messages ]; then
-                sudo cat /var/log/messages > logs/syslog
-            else
-                echo "Failed to get syslogs: neither journalctl nor " \
-                "/var/log/messages were found." > logs/syslogs
-            fi
-            [ -e /var/log/httpd ] && sudo cp -R /var/log/httpd logs
-            [ -e /var/log/squid ] && sudo cp -R /var/log/squid logs
-            sudo chown -R "${{USER}}":"${{USER}}" logs
-            tar -zcf logs.tar.gz logs
+        - capture-logs
     publishers:
         - junit:
             results: nose2-junit.xml

--- a/ci/jobs/pulp-upgrade.yaml
+++ b/ci/jobs/pulp-upgrade.yaml
@@ -218,7 +218,11 @@
                 sudo subscription-manager unregister
                 sudo subscription-manager clean
             fi
+        - capture-logs
     publishers:
+      - archive:
+          artifacts: "*.tar.gz"
+          allow-empty: true
       - junit:
           results: nose2-junit.xml
       - email-notify-owners


### PR DESCRIPTION
Create two commits to better separate:

* Externalize the log capturing logic into a macro
* Use the macro to capture the logs on upgrade jobs