### PR TITLE
Add upgrade jobs starting from Pulp 2.10

### DIFF
--- a/ci/jobs/projects.yaml
+++ b/ci/jobs/projects.yaml
@@ -79,6 +79,7 @@
     pulp_version:
         - 2.8-stable
         - 2.9-stable
+        - 2.10-stable
     upgrade_pulp_version:
         - 2.8-beta
         - 2.8-nightly
@@ -88,10 +89,30 @@
         - 2.10-nightly
         - 2.11-nightly
     exclude:
+        - pulp_version: 2.8-stable
+          upgrade_pulp_version: 2.8-beta
+        - pulp_version: 2.8-stable
+          upgrade_pulp_version: 2.8-nightly
+        - pulp_version: 2.8-stable
+          upgrade_pulp_version: 2.9-beta
+        - pulp_version: 2.8-stable
+          upgrade_pulp_version: 2.9-nightly
         - pulp_version: 2.9-stable
           upgrade_pulp_version: 2.8-beta
         - pulp_version: 2.9-stable
           upgrade_pulp_version: 2.8-nightly
+        - pulp_version: 2.9-stable
+          upgrade_pulp_version: 2.9-beta
+        - pulp_version: 2.9-stable
+          upgrade_pulp_version: 2.9-nightly
+        - pulp_version: 2.10-stable
+          upgrade_pulp_version: 2.8-beta
+        - pulp_version: 2.10-stable
+          upgrade_pulp_version: 2.8-nightly
+        - pulp_version: 2.10-stable
+          upgrade_pulp_version: 2.9-beta
+        - pulp_version: 2.10-stable
+          upgrade_pulp_version: 2.9-nightly
     jobs:
         - 'pulp-upgrade-{pulp_version}-{upgrade_pulp_version}-{os}'
 


### PR DESCRIPTION
The current set of jobs are:

```
pulp-upgrade-2.10-stable-2.10-beta-f23
pulp-upgrade-2.10-stable-2.10-beta-rhel6
pulp-upgrade-2.10-stable-2.10-beta-rhel7
pulp-upgrade-2.10-stable-2.10-nightly-f23
pulp-upgrade-2.10-stable-2.10-nightly-rhel6
pulp-upgrade-2.10-stable-2.10-nightly-rhel7
pulp-upgrade-2.10-stable-2.11-nightly-f23
pulp-upgrade-2.10-stable-2.11-nightly-rhel6
pulp-upgrade-2.10-stable-2.11-nightly-rhel7
pulp-upgrade-2.8-stable-2.10-beta-f23
pulp-upgrade-2.8-stable-2.10-beta-rhel6
pulp-upgrade-2.8-stable-2.10-beta-rhel7
pulp-upgrade-2.8-stable-2.10-nightly-f23
pulp-upgrade-2.8-stable-2.10-nightly-rhel6
pulp-upgrade-2.8-stable-2.10-nightly-rhel7
pulp-upgrade-2.8-stable-2.11-nightly-f23
pulp-upgrade-2.8-stable-2.11-nightly-rhel6
pulp-upgrade-2.8-stable-2.11-nightly-rhel7
pulp-upgrade-2.8-stable-2.8-beta-f23
pulp-upgrade-2.8-stable-2.8-beta-rhel6
pulp-upgrade-2.8-stable-2.8-beta-rhel7
pulp-upgrade-2.8-stable-2.8-nightly-f23
pulp-upgrade-2.8-stable-2.8-nightly-rhel6
pulp-upgrade-2.8-stable-2.8-nightly-rhel7
pulp-upgrade-2.8-stable-2.9-beta-f23
pulp-upgrade-2.8-stable-2.9-beta-rhel6
pulp-upgrade-2.8-stable-2.9-beta-rhel7
pulp-upgrade-2.8-stable-2.9-nightly-f23
pulp-upgrade-2.8-stable-2.9-nightly-rhel6
pulp-upgrade-2.8-stable-2.9-nightly-rhel7
pulp-upgrade-2.9-stable-2.10-beta-f23
pulp-upgrade-2.9-stable-2.10-beta-rhel6
pulp-upgrade-2.9-stable-2.10-beta-rhel7
pulp-upgrade-2.9-stable-2.10-nightly-f23
pulp-upgrade-2.9-stable-2.10-nightly-rhel6
pulp-upgrade-2.9-stable-2.10-nightly-rhel7
pulp-upgrade-2.9-stable-2.11-nightly-f23
pulp-upgrade-2.9-stable-2.11-nightly-rhel6
pulp-upgrade-2.9-stable-2.11-nightly-rhel7
pulp-upgrade-2.9-stable-2.9-beta-f23
pulp-upgrade-2.9-stable-2.9-beta-rhel6
pulp-upgrade-2.9-stable-2.9-beta-rhel7
pulp-upgrade-2.9-stable-2.9-nightly-f23
pulp-upgrade-2.9-stable-2.9-nightly-rhel6
pulp-upgrade-2.9-stable-2.9-nightly-rhel7
```