### PR TITLE
Customize mirrorlist files

### DIFF
--- a/ci/jobs/pulp-fixtures-publisher.yaml
+++ b/ci/jobs/pulp-fixtures-publisher.yaml
@@ -20,6 +20,8 @@
         - shell: |
             sudo dnf -y install createrepo make patch rpm-sign gpg
             make fixtures
+            sed -i 's|http://localhost:8000|https://repos.fedorapeople.org/repos/pulp/pulp|g' \
+                fixtures/rpm-mirrorlist*
             rsync -arvze "ssh -o StrictHostKeyChecking=no" --delete \
                 fixtures/* \
                 pulpadmin@repos.fedorapeople.org:/srv/repos/pulp/pulp/fixtures


### PR DESCRIPTION
Pulp Fixtures generates mirrorlist files. The mirrorlist files contain
absolute URLs starting with http://localhost:8000/…. These URLs are
valid when fixtures are served with ``python3 -m http.server``, but not
when the fixtures are served with some other technique. Customize these
base URLs before copying the fixtures to their hosting system.

See: https://github.com/PulpQE/pulp-smash/issues/384