### PR TITLE
Customize mirrorlist files

### DIFF
--- a/ci/jobs/pulp-fixtures-publisher.yaml
+++ b/ci/jobs/pulp-fixtures-publisher.yaml
@@ -19,7 +19,7 @@
     builders:
         - shell: |
             sudo dnf -y install createrepo make patch rpm-sign gpg
-            make fixtures
+            make fixtures base_url=https://repos.fedorapeople.org/pulp/pulp
             rsync -arvze "ssh -o StrictHostKeyChecking=no" --delete \
                 fixtures/* \
                 pulpadmin@repos.fedorapeople.org:/srv/repos/pulp/pulp/fixtures


### PR DESCRIPTION
Pulp Fixtures is capable of generating mirrorlist files. The mirrorlist
files contain absolute URLs that, by default, start with a base URL of
http://localhost:8000/…. These URLs are valid when fixtures are served
with `python3 -m http.server`, but not when the fixtures are served with
some other technique. Customize these base URLs.

See: https://github.com/PulpQE/pulp-smash/issues/384