### PR TITLE
Update options to install Pulp 2.11 by default

### DIFF
--- a/ci/ansible/roles/pulp/defaults/main.yaml
+++ b/ci/ansible/roles/pulp/defaults/main.yaml
@@ -7,7 +7,7 @@ pulp_install_prerequisites: true
 pulp_install_server: true
 
 # Pulp version to install
-pulp_version: 2.9
+pulp_version: 2.11
 
 # Pulp build to install, the choices are: beta, nightly and stable
 pulp_build: nightly

--- a/ci/jobs/pulp-installer.yaml
+++ b/ci/jobs/pulp-installer.yaml
@@ -20,6 +20,7 @@
         - choice:
             name: PULP_VERSION
             choices:
+                - '2.11'
                 - '2.10'
                 - '2.9'
                 - '2.8'


### PR DESCRIPTION
Make ansible playbook and pulp-installer job to install 2.11 by default.