### PR TITLE
Improve ssh-config for pulp-smash runner

### DIFF
--- a/ci/jobs/pulp-dev.yaml
+++ b/ci/jobs/pulp-dev.yaml
@@ -134,12 +134,16 @@
     builders:
         - shell: |
             # Setup ssh config and private key
+            mkdir ~/.ssh/controlmasters
             cat > ~/.ssh/config <<EOF
             Host $(echo ${BASE_URL} | cut -d/ -f3)
                 User jenkins
                 StrictHostKeyChecking no
                 UserKnownHostsFile /dev/null
                 IdentityFile ${PWD}/PRIVATE_KEY
+                ControlMaster auto
+                ControlPersist 5m
+                ControlPath ~/.ssh/controlmasters/%C
             EOF
             chmod 600 PRIVATE_KEY ~/.ssh/config
 


### PR DESCRIPTION
Add ControlMaster, ControlPersist and ControlPath options to the
pulp-smash-runner's ssh-config. This will speed up running Pulp Smash tests.