### PR TITLE
Install attr package before running Pulp Smash

### DIFF
--- a/ci/jobs/pulp-dev.yaml
+++ b/ci/jobs/pulp-dev.yaml
@@ -156,7 +156,7 @@
             sudo cp CA_CERT /etc/pki/ca-trust/source/anchors/cacert.pem
             sudo update-ca-trust
 
-            sudo yum -y install python-pip python-virtualenv
+            sudo yum -y install python-pip python-virtualenv attr
             virtualenv -p /usr/bin/python3 venv
             source venv/bin/activate
             git clone http://github.com/PulpQE/pulp-smash.git


### PR DESCRIPTION
Pulp Smash is now making use of `getfattr` command, that said, make sure
the attr package, which provides `getfattr` command, is installed.

For more information check related Pulp Smash PR
https://github.com/PulpQE/pulp-smash/pull/455.