### PR TITLE
Improve pre and post upgrade scripts

### DIFF
--- a/ci/jobs/scripts/post-upgrade.sh
+++ b/ci/jobs/scripts/post-upgrade.sh
@@ -1,19 +1,24 @@
 #!/bin/bash
 
-pulp-admin login -u "${PULP_USER}" -p "${PULP_PASSWORD}"
+pulp-admin login -u "${PULP_USER:-admin}" -p "${PULP_PASSWORD:-admin}"
 
-pulp-admin rpm repo list --repo-id drpm
-pulp-admin rpm repo list --repo-id srpm
-pulp-admin rpm repo list --repo-id rhel6
-pulp-admin rpm repo list --repo-id centos5
-pulp-admin rpm repo list --repo-id zoo
-pulp-admin puppet repo list --repo-id forge
-pulp-admin rpm repo list --repo-id repo_1
-pulp-admin rpm repo list --repo-id file-feed
+for repo in busybox docker registry; do
+    pulp-admin docker repo list --repo-id "${repo}"
+done
 pulp-admin iso repo list --repo-id filerepo
-if [ "$(echo -e 2.8\\n${PULP_VERSION} | sort -V | head -n 1)" = "2.8" ]; then
-    pulp-admin docker repo list --repo-id busybox
+pulp-admin puppet repo list --repo-id forge
+pulp-admin python repo list --repo-id pypi
+pulp-admin python repo list --repo-id python-upload
+pulp-admin rpm repo list --repo-id centos5
+pulp-admin rpm repo list --repo-id drpm
+pulp-admin rpm repo list --repo-id file-feed
+pulp-admin rpm repo list --repo-id rpm-signed
+pulp-admin rpm repo list --repo-id srpm
+pulp-admin rpm repo list --repo-id sync-schedule
+
+if [[ -f "${CDN_CERTIFICATES}" ]]; then
+    pulp-admin rpm repo list --repo-id rhel6
+    pulp-admin rpm repo list --repo-id rhel7-rhn-tools
 fi
-pulp-admin rpm repo list --repo-id rhel7-rhn-tools
 
 pulp-admin logout

--- a/ci/jobs/scripts/pre-upgrade.sh
+++ b/ci/jobs/scripts/pre-upgrade.sh
@@ -1,10 +1,29 @@
 #!/bin/bash
 
+pulp-admin login -u "${PULP_USER:-admin}" -p "${PULP_PASSWORD:-admin}"
+
 if [[ -f "${CDN_CERTIFICATES}" ]]; then
     tar -zxvf "${CDN_CERTIFICATES}"
-fi
 
-pulp-admin login -u "${PULP_USER}" -p "${PULP_PASSWORD}"
+    pulp-admin rpm repo create \
+        --feed https://cdn.redhat.com/content/dist/rhel/rhui/server/6/6.7/x86_64/kickstart/ \
+        --feed-ca-cert cdn/cdn.redhat.com-chain.crt \
+        --feed-cert cdn/914f702153514b06c1ef279db9dcadce.crt \
+        --feed-key cdn/914f702153514b06c1ef279db9dcadce.key \
+        --remove-missing true \
+        --repo-id rhel6 \
+        --serve-http true
+    pulp-admin rpm repo sync run --repo-id rhel6
+
+    pulp-admin rpm repo create \
+        --feed https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/x86_64/rhn-tools/os/ \
+        --feed-ca-cert cdn/cdn.redhat.com-chain.crt \
+        --feed-cert cdn/914f702153514b06c1ef279db9dcadce.crt \
+        --feed-key cdn/914f702153514b06c1ef279db9dcadce.key \
+        --repo-id rhel7-rhn-tools \
+        --skip erratum
+    pulp-admin rpm repo sync run --repo-id rhel7-rhn-tools
+fi
 
 pulp-admin rpm repo create \
     --feed https://repos.fedorapeople.org/pulp/pulp/fixtures/drpm-unsigned/ \
@@ -19,71 +38,73 @@ pulp-admin rpm repo create \
 pulp-admin rpm repo sync run --repo-id srpm
 
 pulp-admin rpm repo create \
-    --feed https://cdn.redhat.com/content/dist/rhel/rhui/server/6/6.7/x86_64/kickstart/ \
-    --feed-ca-cert cdn/cdn.redhat.com-chain.crt \
-    --feed-cert cdn/914f702153514b06c1ef279db9dcadce.crt \
-    --feed-key cdn/914f702153514b06c1ef279db9dcadce.key \
-    --remove-missing true \
-    --repo-id rhel6 \
-    --serve-http true
-pulp-admin rpm repo sync run --repo-id rhel6
-
-pulp-admin rpm repo create \
     --checksum-type sha \
-    --feed http://ftp.linux.ncsu.edu/pub/CentOS/5.11/os/x86_64/ \
+    --feed http://mirror.centos.org/centos-5/5/os/x86_64/ \
     --repo-id centos5 \
     --serve-http true \
     --skip erratum
 pulp-admin rpm repo sync run --repo-id centos5
 
 pulp-admin rpm repo create \
-    --feed http://repos.fedorapeople.org/repos/pulp/pulp/demo_repos/zoo \
-    --relative-url zoo \
-    --repo-id zoo \
+    --feed https://repos.fedorapeople.org/pulp/pulp/fixtures/rpm-signed/ \
+    --relative-url sync-schedule \
+    --repo-id sync-schedule \
     --retain-old-count 0
-
-pulp-admin rpm repo sync run --repo-id zoo
+pulp-admin rpm repo sync run --repo-id sync-schedule
 pulp-admin rpm repo sync schedules create \
-    --repo-id zoo \
+    --repo-id sync-schedule \
     --schedule 2015-06-06T14:29:00Z/PT1M
+
+pulp-admin rpm repo create \
+    --feed https://repos.fedorapeople.org/pulp/pulp/fixtures/rpm-signed/ \
+    --relative-url rpm-signed \
+    --repo-id rpm-signed \
+    --serve-http true \
+    --serve-https true
+pulp-admin rpm repo sync run --repo-id rpm-signed
+pulp-admin rpm repo publish run --repo-id rpm-signed
+
+# The file-feed repo depends on the rpm-signed being published over https
+pulp-admin rpm repo create \
+    --feed file:///var/lib/pulp/published/yum/https/repos/rpm-signed/ \
+    --repo-id file-feed
+pulp-admin rpm repo sync run --repo-id file-feed
+
 
 pulp-admin puppet repo create \
     --feed http://forge.puppetlabs.com \
+    --queries puppetlabs \
     --repo-id forge
 pulp-admin puppet repo sync run --repo-id forge
-
-pulp-admin rpm repo create \
-    --feed http://repos.fedorapeople.org/repos/pulp/pulp/demo_repos/pulp_unittest/ \
-    --repo-id repo_1
-
-pulp-admin rpm repo create \
-    --feed file:///var/lib/pulp/published/yum/https/repos/repos/pulp/pulp/demo_repos/zoo/ \
-    --repo-id file-feed
-pulp-admin rpm repo sync run --repo-id file-feed
 
 pulp-admin iso repo create \
     --feed https://repos.fedorapeople.org/repos/pulp/pulp/demo_repos/test_file_repo/ \
     --repo-id filerepo
 pulp-admin iso repo sync run --repo-id filerepo
 
-if [ "$(echo -e 2.8\\n${PULP_VERSION} | sort -V | head -n 1)" = "2.8" ]; then
+for repo in busybox docker registry; do
     pulp-admin docker repo create \
-        --feed https://index.docker.io \
-        --repo-id busybox \
-        --upstream-name busybox
-    pulp-admin docker repo sync run --repo-id busybox
-fi
+        --feed https://registry-1.docker.io \
+        --repo-id "${repo}" \
+        --upstream-name "${repo}"
+    pulp-admin docker repo sync run --repo-id "${repo}"
+done
 
-pulp-admin repo group create --group-id my-zoo --display-name "My Zoo"
-pulp-admin repo group members add  --group-id my-zoo --repo-id zoo
+pulp-admin python repo create \
+    --feed https://pypi.python.org/ \
+    --package-names requests,pulp-smash \
+    --repo-id pypi
+pulp-admin python repo sync run --repo-id pypi
 
-pulp-admin rpm repo create \
-    --feed https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/x86_64/rhn-tools/os/ \
-    --feed-ca-cert cdn/cdn.redhat.com-chain.crt \
-    --feed-cert cdn/914f702153514b06c1ef279db9dcadce.crt \
-    --feed-key cdn/914f702153514b06c1ef279db9dcadce.key \
-    --repo-id rhel7-rhn-tools \
-    --skip erratum
-pulp-admin rpm repo sync run --repo-id rhel7-rhn-tools
+pulp-admin python repo create --repo-id python-upload
+git clone https://github.com/pulp/pulp_python.git --branch 0.0-dev
+cd pulp_python/plugins || exit 1
+./setup.py sdist
+pulp-admin python repo upload --repo-id python-upload -f dist/pulp_python_plugins-0.0.0.tar.gz
+pulp-admin python repo publish run --repo-id python-upload
+cd - || exit 1
+
+pulp-admin repo group create --group-id repo-group --display-name "Repo Group"
+pulp-admin repo group members add  --group-id repo-group --repo-id sync-schedule
 
 pulp-admin logout


### PR DESCRIPTION
The improvements are:

* Sync Python content
* Use queries to sync fewer Puppet modules instead of entire Puppet
  Forge
* Use pulp-fixtures repositories instead of demo_repos
* Sync centos5 from an official mirror URL
* Remove repo_1 repository
* Fix file-feed repo feed path
* Add more Docker images to sync