### PR TITLE
Update prepare_node.sh

### DIFF
--- a/ci/nodepool/scripts/prepare_node.sh
+++ b/ci/nodepool/scripts/prepare_node.sh
@@ -13,8 +13,8 @@ source bootstrap.sh
 echo "Performaing a general update"
 sudo "${PKG_MGR}" update -y
 
-echo "Installing base packages"
-sudo "${PKG_MGR}" install -y gcc git python-devel python-pip redhat-lsb-core wget
+echo "Installing base packages and compiler requirements"
+sudo "${PKG_MGR}" install -y gcc git python-devel python-pip redhat-lsb-core wget redhat-rpm-config libffi-devel openssl-devel
 
 echo "OS specific setup"
 if [ "${DISTRIBUTION}" == "redhat" ] && [ "${DISTRIBUTION_MAJOR_VERSION}" == "5" ]; then


### PR DESCRIPTION
After a recent change that stopped running our puppet modules, these packages
needed to be manually installed to get the redmine-bugzilla-automation job working.

Since it was a change the prepare_node.sh script that most likely caused that problem,
I think it's probably a good idea to put the fix in the same file.