### PR TITLE
Use updated RHEL images, remove grub hack

### DIFF
--- a/ci/nodepool/nodepool.yaml
+++ b/ci/nodepool/nodepool.yaml
@@ -166,30 +166,32 @@ providers:
         setup: prepare_node.sh
         private-key: /etc/nodepool/pulp_rsa
         min-ram: 3072
+        # for rhel images, the "updated" images should require less updating
+        # than the "released" images: https://mojo.redhat.com/docs/DOC-1081665
         # rhel6 images need the t2.medium image type because their initrd
         # explodes on the ephemeral volumes
       - name: rhel6-np
-        base-image: rhel-6.8-server-x86_64-released
+        base-image: rhel-6.8-server-x86_64-updated
         username: jenkins
         setup: prepare_node.sh
         private-key: /etc/nodepool/pulp_rsa
         min-ram: 4096
         name-filter: t2.medium
       - name: rhel6-vanilla-np
-        base-image: rhel-6.8-server-x86_64-released
+        base-image: rhel-6.8-server-x86_64-updated
         username: jenkins
         setup: prepare_node.sh
         private-key: /etc/nodepool/pulp_rsa
         min-ram: 4096
         name-filter: t2.medium
       - name: rhel7-np
-        base-image: rhel-7.3-server-x86_64-released
+        base-image: rhel-7.3-server-x86_64-updated
         username: jenkins
         setup: prepare_node.sh
         private-key: /etc/nodepool/pulp_rsa
         min-ram: 4096
       - name: rhel7-vanilla-np
-        base-image: rhel-7.3-server-x86_64-released
+        base-image: rhel-7.3-server-x86_64-updated
         username: jenkins
         setup: prepare_node.sh
         private-key: /etc/nodepool/pulp_rsa

--- a/ci/nodepool/scripts/prepare_node.sh
+++ b/ci/nodepool/scripts/prepare_node.sh
@@ -34,13 +34,6 @@ elif  [ "${DISTRIBUTION}" == "redhat" ] && [ "${DISTRIBUTION_MAJOR_VERSION}" == 
     sudo su -c "curl https://copr.fedorainfracloud.org/coprs/g/qpid/qpid/repo/epel-6/irina-qpid-epel-6.repo > /etc/yum.repos.d/copr-qpid.repo"
 elif  [ "${DISTRIBUTION}" == "redhat" ] && [ "${DISTRIBUTION_MAJOR_VERSION}" == "7" ]; then
     sudo rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-    # https://bugzilla.redhat.com/show_bug.cgi?id=1173993 is similar to what we've been seeing
-    # to break the rhel7 image booting. This fixes it, but it's not clear why.
-    sudo sed -i '/sixteenbit=/d' /etc/grub.d/10_linux
-    # after fixing that ^, the rhel7-vanilla images occasional kernel panic starting the apic timer
-    # simple solution: don't use apic?
-    sudo sed -i 's/GRUB_CMDLINE_LINUX="/GRUB_CMDLINE_LINUX="apic=verbose /' /etc/default/grub
-    sudo grub2-mkconfig -o /boot/grub2/grub.cfg
 elif  [ "${DISTRIBUTION}" == "fedora" ]; then
     sudo sed -i 's/clean_requirements_on_remove=true/clean_requirements_on_remove=false/g' /etc/dnf/dnf.conf
     # "which" isn't installed in fedora 22+ by default?


### PR DESCRIPTION
When using the "updated" rhel 7.3 image base, the el7 grub hack in
prepare_node is no longer necessary. This hack was causing a syntax
error in the grub config which prevented our prepared images from
booting.

I did test building the el6 images on the "updated" base, and they
appear to be working correctly.