### PR TITLE
Add puppet repo to rhel6-np nodes

### DIFF
--- a/ci/nodepool/scripts/prepare_node.sh
+++ b/ci/nodepool/scripts/prepare_node.sh
@@ -31,6 +31,8 @@ EOF
     sudo mv mrg.repo /etc/yum.repos.d/
 elif  [ "${DISTRIBUTION}" == "redhat" ] && [ "${DISTRIBUTION_MAJOR_VERSION}" == "6" ]; then
     sudo rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
+    # el6 doesn't have a new enough puppet to meet plugin dependencies
+    sudo rpm -ivh https://yum.puppetlabs.com/puppetlabs-release-pc1-el-6.noarch.rpm
     sudo su -c "curl https://copr.fedorainfracloud.org/coprs/g/qpid/qpid/repo/epel-6/irina-qpid-epel-6.repo > /etc/yum.repos.d/copr-qpid.repo"
 elif  [ "${DISTRIBUTION}" == "redhat" ] && [ "${DISTRIBUTION_MAJOR_VERSION}" == "7" ]; then
     sudo rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm


### PR DESCRIPTION
The puppet plugin needs a newer version of puppet than is available
in rhel6.