### PR TITLE
Install attr package for upgrade jobs

### DIFF
--- a/ci/jobs/pulp-upgrade.yaml
+++ b/ci/jobs/pulp-upgrade.yaml
@@ -36,7 +36,7 @@
         - inject:
             properties-file: pulp_version.properties
         - shell: |
-            sudo yum install -y git ansible libselinux-python
+            sudo yum -y install ansible attr git libselinux-python
             ssh-keygen -t rsa -N "" -f pulp_server_key
             cat pulp_server_key.pub >> ~/.ssh/authorized_keys
             export ANSIBLE_HOST_KEY_CHECKING=False


### PR DESCRIPTION
The attr package is needed by Pulp Smash in order to run some tests,
make sure the Pulp Server machines for the upgrade jobs have that
package installed.