### PR TITLE
Update Pulp upgrade jobs project

### DIFF
--- a/ci/jobs/projects.yaml
+++ b/ci/jobs/projects.yaml
@@ -73,47 +73,24 @@
 - project:
     name: pulp-upgrade
     os:
-        - f23
+        - f24
         - rhel6
         - rhel7
     pulp_version:
         - 2.8-stable
         - 2.9-stable
         - 2.10-stable
+        - 2.11-stable
     upgrade_pulp_version:
-        - 2.8-beta
-        - 2.8-nightly
-        - 2.9-beta
-        - 2.9-nightly
         - 2.10-beta
         - 2.10-nightly
         - 2.11-beta
         - 2.11-nightly
     exclude:
-        - pulp_version: 2.8-stable
-          upgrade_pulp_version: 2.8-beta
-        - pulp_version: 2.8-stable
-          upgrade_pulp_version: 2.8-nightly
-        - pulp_version: 2.8-stable
-          upgrade_pulp_version: 2.9-beta
-        - pulp_version: 2.8-stable
-          upgrade_pulp_version: 2.9-nightly
-        - pulp_version: 2.9-stable
-          upgrade_pulp_version: 2.8-beta
-        - pulp_version: 2.9-stable
-          upgrade_pulp_version: 2.8-nightly
-        - pulp_version: 2.9-stable
-          upgrade_pulp_version: 2.9-beta
-        - pulp_version: 2.9-stable
-          upgrade_pulp_version: 2.9-nightly
-        - pulp_version: 2.10-stable
-          upgrade_pulp_version: 2.8-beta
-        - pulp_version: 2.10-stable
-          upgrade_pulp_version: 2.8-nightly
-        - pulp_version: 2.10-stable
-          upgrade_pulp_version: 2.9-beta
-        - pulp_version: 2.10-stable
-          upgrade_pulp_version: 2.9-nightly
+        - pulp_version: 2.11-stable
+          upgrade_pulp_version: 2.10-beta
+        - pulp_version: 2.11-stable
+          upgrade_pulp_version: 2.10-nightly
     jobs:
         - 'pulp-upgrade-{pulp_version}-{upgrade_pulp_version}-{os}'
 


### PR DESCRIPTION
Upgrade to Pulp 2.10 and 2.11 and drop upgrade to 2.8 and 2.9, also
update upgrade on Fedora to Fedora 24.

Current managed jobs list is:

```
pulp-upgrade-2.10-stable-2.10-beta-f24
pulp-upgrade-2.10-stable-2.10-beta-rhel6
pulp-upgrade-2.10-stable-2.10-beta-rhel7
pulp-upgrade-2.10-stable-2.10-nightly-f24
pulp-upgrade-2.10-stable-2.10-nightly-rhel6
pulp-upgrade-2.10-stable-2.10-nightly-rhel7
pulp-upgrade-2.10-stable-2.11-beta-f24
pulp-upgrade-2.10-stable-2.11-beta-rhel6
pulp-upgrade-2.10-stable-2.11-beta-rhel7
pulp-upgrade-2.10-stable-2.11-nightly-f24
pulp-upgrade-2.10-stable-2.11-nightly-rhel6
pulp-upgrade-2.10-stable-2.11-nightly-rhel7
pulp-upgrade-2.11-stable-2.11-beta-f24
pulp-upgrade-2.11-stable-2.11-beta-rhel6
pulp-upgrade-2.11-stable-2.11-beta-rhel7
pulp-upgrade-2.11-stable-2.11-nightly-f24
pulp-upgrade-2.11-stable-2.11-nightly-rhel6
pulp-upgrade-2.11-stable-2.11-nightly-rhel7
pulp-upgrade-2.8-stable-2.10-beta-f24
pulp-upgrade-2.8-stable-2.10-beta-rhel6
pulp-upgrade-2.8-stable-2.10-beta-rhel7
pulp-upgrade-2.8-stable-2.10-nightly-f24
pulp-upgrade-2.8-stable-2.10-nightly-rhel6
pulp-upgrade-2.8-stable-2.10-nightly-rhel7
pulp-upgrade-2.8-stable-2.11-beta-f24
pulp-upgrade-2.8-stable-2.11-beta-rhel6
pulp-upgrade-2.8-stable-2.11-beta-rhel7
pulp-upgrade-2.8-stable-2.11-nightly-f24
pulp-upgrade-2.8-stable-2.11-nightly-rhel6
pulp-upgrade-2.8-stable-2.11-nightly-rhel7
pulp-upgrade-2.9-stable-2.10-beta-f24
pulp-upgrade-2.9-stable-2.10-beta-rhel6
pulp-upgrade-2.9-stable-2.10-beta-rhel7
pulp-upgrade-2.9-stable-2.10-nightly-f24
pulp-upgrade-2.9-stable-2.10-nightly-rhel6
pulp-upgrade-2.9-stable-2.10-nightly-rhel7
pulp-upgrade-2.9-stable-2.11-beta-f24
pulp-upgrade-2.9-stable-2.11-beta-rhel6
pulp-upgrade-2.9-stable-2.11-beta-rhel7
pulp-upgrade-2.9-stable-2.11-nightly-f24
pulp-upgrade-2.9-stable-2.11-nightly-rhel6
pulp-upgrade-2.9-stable-2.11-nightly-rhel7
```