### PR TITLE
Update nightly automation permutations

### DIFF
--- a/ci/jobs/projects.yaml
+++ b/ci/jobs/projects.yaml
@@ -48,7 +48,7 @@
     name: pulp-dev
     os:
         - 'f24'
-        - 'f23'
+        - 'f25'
         - 'rhel6'
         - 'rhel7'
     pulp_version:
@@ -56,6 +56,9 @@
         - '2.11'
         - '2.12':
             reverse_trigger: 'master'
+    exclude:
+        - pulp_version: '2.10'
+          os: 'f25'
     reverse_trigger: '{pulp_version}-dev'
     jobs:
         - pulp-{pulp_version}-dev-{os}


### PR DESCRIPTION
Test 2.11 and 2.12 on Fedora 25 and stop testing Pulp on Fedora 23.

These are the generated jobs with this config:

```
INFO:jenkins_jobs.builder:Job name:  pulp-2.10-dev-f24
INFO:jenkins_jobs.builder:Job name:  pulp-2.10-dev-rhel6
INFO:jenkins_jobs.builder:Job name:  pulp-2.10-dev-rhel7
INFO:jenkins_jobs.builder:Job name:  pulp-2.11-dev-f24
INFO:jenkins_jobs.builder:Job name:  pulp-2.11-dev-f25
INFO:jenkins_jobs.builder:Job name:  pulp-2.11-dev-rhel6
INFO:jenkins_jobs.builder:Job name:  pulp-2.11-dev-rhel7
INFO:jenkins_jobs.builder:Job name:  pulp-2.12-dev-f24
INFO:jenkins_jobs.builder:Job name:  pulp-2.12-dev-f25
INFO:jenkins_jobs.builder:Job name:  pulp-2.12-dev-rhel6
INFO:jenkins_jobs.builder:Job name:  pulp-2.12-dev-rhel7
```