### PR TITLE
Use f25 nodes, don't use f23 nodes, remove vanilla labels

### DIFF
--- a/ci/jobs/ci-update-jobs.yaml
+++ b/ci/jobs/ci-update-jobs.yaml
@@ -1,7 +1,7 @@
 # This job updates all the jenkins jobs with the latest contents of the JJB definitions.
 - job:
     name: ci-update-jobs
-    node: f23-np
+    node: fedora-np
     properties:
         - qe-ownership
     scm:

--- a/ci/jobs/docs.yaml
+++ b/ci/jobs/docs.yaml
@@ -4,7 +4,7 @@
 - job-template:
     name: 'docs-builder-{release_config}'
     defaults: ci-workflow-runtest
-    node: 'f23-np'
+    node: 'fedora-np'
     properties:
         - docs-ownership
     scm:

--- a/ci/jobs/projects.yaml
+++ b/ci/jobs/projects.yaml
@@ -141,7 +141,7 @@
             - master
           unittest_platforms:
             - f24-np
-            - f23-np
+            - f25-np
             - rhel6-np
             - rhel7-np
       - pulp_docker:
@@ -154,7 +154,7 @@
             - 2.2-dev
           unittest_platforms:
             - f24-np
-            - f23-np
+            - f25-np
             - rhel6-np
             - rhel7-np
       - pulp_ostree:
@@ -166,7 +166,7 @@
             - 1.22dev
           unittest_platforms:
             - f24-np
-            - f23-np
+            - f25-np
             - rhel7-np
       - pulp_puppet:
           min_coverage: 95
@@ -179,7 +179,7 @@
             - master
           unittest_platforms:
             - f24-np
-            - f23-np
+            - f25-np
             - rhel6-np
             - rhel7-np
       - pulp_python:
@@ -191,7 +191,7 @@
             - master
           unittest_platforms:
             - f24-np
-            - f23-np
+            - f25-np
             - rhel6-np
             - rhel7-np
       - pulp_rpm:
@@ -205,6 +205,6 @@
             - master
           unittest_platforms:
             - f24-np
-            - f23-np
+            - f25-np
             - rhel6-np
             - rhel7-np

--- a/ci/jobs/pulp-dev.yaml
+++ b/ci/jobs/pulp-dev.yaml
@@ -1,6 +1,6 @@
 - job-template:
     name: 'pulp-{pulp_version}-dev-{os}'
-    node: '{os}-vanilla-np'
+    node: '{os}-np'
     properties:
         - qe-ownership
     scm:

--- a/ci/jobs/pulp-fixtures-publisher.yaml
+++ b/ci/jobs/pulp-fixtures-publisher.yaml
@@ -3,7 +3,7 @@
 
 - job-template:
     name: 'pulp-fixtures-publisher'
-    node: 'f23-docker-np'
+    node: 'docker-np'
     properties:
         - qe-ownership
     scm:

--- a/ci/jobs/pulp-installer.yaml
+++ b/ci/jobs/pulp-installer.yaml
@@ -2,7 +2,7 @@
 # machines for running Pulp Smash.
 - job:
     name: 'pulp-installer'
-    node: 'f25-vanilla-np'
+    node: 'fedora-np'
     description: |
         <p>Job that installs Pulp on the machine identified by the job
         parameter.</p>

--- a/ci/jobs/pulp-upgrade.yaml
+++ b/ci/jobs/pulp-upgrade.yaml
@@ -3,7 +3,7 @@
 
 - job-template:
     name: 'pulp-upgrade-{pulp_version}-{upgrade_pulp_version}-{os}'
-    node: '{os}-vanilla-np'
+    node: '{os}-np'
     properties:
         - qe-ownership
     scm:

--- a/ci/jobs/redmine.yaml
+++ b/ci/jobs/redmine.yaml
@@ -4,7 +4,7 @@
 - job-template:
     name: 'redmine-bugzilla-automation'
     defaults: ci-workflow-runtest
-    node: 'f23-np'
+    node: 'fedora-np'
     properties:
         - dev-ownership
     scm:

--- a/ci/jobs/satellite6-upgrade-pulp.yaml
+++ b/ci/jobs/satellite6-upgrade-pulp.yaml
@@ -72,7 +72,7 @@
 #
 - job-template:
     name: '{stream}-satellite6-upgrade-pulp'
-    node: f23-vanilla-np
+    node: fedora-np
     properties:
         - qe-ownership
     wrappers:

--- a/ci/jobs/unittests.yaml
+++ b/ci/jobs/unittests.yaml
@@ -8,7 +8,7 @@
           type: label-expression
           name: node-type
           values:
-            - f23-np
+            - f25-np
             - rhel6-np
             - rhel7-np
     parameters:

--- a/ci/nodepool/nodepool.yaml
+++ b/ci/nodepool/nodepool.yaml
@@ -14,26 +14,25 @@ cron:
   cleanup: '*/1 * * * *'
 
 labels:
+  # unversioned labels used to abstract the distribution version from the job,
+  # useful where the job just wants the latest available fedora, not a specific version.
+  # pulp-smash gets its own label to help nodepool's node launch calculations keep smash
+  # nodes available when they're needed
   - name: pulp-smash-np
-    image: f23-np
+    image: f25-np
     min-ready: 0
     providers:
       - name: cios
     ready-script: fix_hostname.sh
-  - name: f23-np
-    image: f23-np
+  - name: fedora-np
+    image: f25-np
     min-ready: 0
     providers:
       - name: cios
     ready-script: fix_hostname.sh
-  - name: f23-vanilla-np
-    image: f23-vanilla-np
-    min-ready: 0
-    providers:
-      - name: cios
-    ready-script: fix_hostname.sh
-  - name: f23-docker-np
-    image: f23-docker-np
+  # unversioned docker image, similar to fedora-np, but with docker installed
+  - name: docker-np
+    image: docker-np
     min-ready: 0
     providers:
       - name: cios
@@ -44,20 +43,8 @@ labels:
     providers:
       - name: cios
     ready-script: fix_hostname.sh
-  - name: f24-vanilla-np
-    image: f24-vanilla-np
-    min-ready: 0
-    providers:
-      - name: cios
-    ready-script: fix_hostname.sh
   - name: f25-np
     image: f25-np
-    min-ready: 0
-    providers:
-      - name: cios
-    ready-script: fix_hostname.sh
-  - name: f25-vanilla-np
-    image: f25-vanilla-np
     min-ready: 0
     providers:
       - name: cios
@@ -68,20 +55,8 @@ labels:
     providers:
       - name: cios
     ready-script: fix_hostname.sh
-  - name: rhel6-vanilla-np
-    image: rhel6-vanilla-np
-    min-ready: 0
-    providers:
-      - name: cios
-    ready-script: fix_hostname.sh
   - name: rhel7-np
     image: rhel7-np
-    min-ready: 0
-    providers:
-      - name: cios
-    ready-script: fix_hostname.sh
-  - name: rhel7-vanilla-np
-    image: rhel7-vanilla-np
     min-ready: 0
     providers:
       - name: cios
@@ -100,43 +75,19 @@ providers:
     pool: "10.8.180.0/22"
     clean-floating-ips: true
     images:
-      - name: f23-np
-        base-image: Fedora-Cloud-Base-23-20151113-py27.x86_64
-        username: jenkins
-        setup: prepare_node.sh
-        private-key: /etc/nodepool/pulp_rsa
-        min-ram: 3072
-      - name: f23-vanilla-np
-        base-image: Fedora-Cloud-Base-23-20151113-py27.x86_64
-        username: jenkins
-        setup: prepare_node.sh
-        private-key: /etc/nodepool/pulp_rsa
-        min-ram: 3072
-      - name: f23-docker-np
-        base-image: Fedora-Cloud-Base-23-20151113-py27.x86_64
-        username: jenkins
-        setup: prepare_node.sh
-        private-key: /etc/nodepool/pulp_rsa
-        min-ram: 3072
-      - name: f24-np
-        base-image: Fedora-Cloud-Base-24-1.2.x86_64
-        username: jenkins
-        setup: prepare_node.sh
-        private-key: /etc/nodepool/pulp_rsa
-        min-ram: 3072
-      - name: f24-vanilla-np
-        base-image: Fedora-Cloud-Base-24-1.2.x86_64
-        username: jenkins
-        setup: prepare_node.sh
-        private-key: /etc/nodepool/pulp_rsa
-        min-ram: 3072
-      - name: f25-np
+      - name: docker-np
         base-image: Fedora-Cloud-Base-25-compose-latest
         username: jenkins
         setup: prepare_node.sh
         private-key: /etc/nodepool/pulp_rsa
         min-ram: 3072
-      - name: f25-vanilla-np
+      - name: f24-np
+        base-image: Fedora-Cloud-Base-24-compose-latest
+        username: jenkins
+        setup: prepare_node.sh
+        private-key: /etc/nodepool/pulp_rsa
+        min-ram: 3072
+      - name: f25-np
         base-image: Fedora-Cloud-Base-25-compose-latest
         username: jenkins
         setup: prepare_node.sh
@@ -153,20 +104,7 @@ providers:
         private-key: /etc/nodepool/pulp_rsa
         min-ram: 4096
         name-filter: t2.medium
-      - name: rhel6-vanilla-np
-        base-image: rhel-6.8-server-x86_64-updated
-        username: jenkins
-        setup: prepare_node.sh
-        private-key: /etc/nodepool/pulp_rsa
-        min-ram: 4096
-        name-filter: t2.medium
       - name: rhel7-np
-        base-image: rhel-7.3-server-x86_64-updated
-        username: jenkins
-        setup: prepare_node.sh
-        private-key: /etc/nodepool/pulp_rsa
-        min-ram: 4096
-      - name: rhel7-vanilla-np
         base-image: rhel-7.3-server-x86_64-updated
         username: jenkins
         setup: prepare_node.sh


### PR DESCRIPTION
With the removal of the puppet stuff in nodepool's prepare_node script, the vanilla nodes are now identical to the non-vanilla nodes. We fixed up the PR tester jobs to install the missing stuff that the puppet modules used to be installing, so now the former differences between the vanilla and non-vanilla nodes is captures in the PR tester jobs themselves. So, this commit merges two  things:

1. Replace all f23 jobs with f25 jobs per our fedora support policy
2. Replace all vanilla nodes with non-vanilla nodes and clean out references to vanilla nodes from nodepool's configs