### PR TITLE
Update upgrade jobs permutations

### DIFF
--- a/ci/jobs/projects.yaml
+++ b/ci/jobs/projects.yaml
@@ -97,6 +97,10 @@
           upgrade_pulp_version: 2.10-beta
         - pulp_version: 2.11-stable
           upgrade_pulp_version: 2.10-nightly
+        - os: f24
+          pulp_version: 2.8-stable
+        - os: f24
+          pulp_version: 2.9-stable
     jobs:
         - 'pulp-upgrade-{pulp_version}-{upgrade_pulp_version}-{os}'
 


### PR DESCRIPTION
Pulp 2.8 and 2.9 packages are not available for Fedora 24, that said,
remove the related permutations.