### PR TITLE
Modernize privilege escalation procedure

### DIFF
--- a/ci/ansible/pulp_coverage.yaml
+++ b/ci/ansible/pulp_coverage.yaml
@@ -2,4 +2,5 @@
 - hosts: all
   roles:
     - role: pulp-coverage
-  sudo: true
+  become: true
+  become_method: sudo

--- a/ci/ansible/pulp_server.yaml
+++ b/ci/ansible/pulp_server.yaml
@@ -7,4 +7,5 @@
     - role: lazy
       when: pulp_version | version_compare('2.8', '>=')
     - role: pulp-certs
-  sudo: true
+  become: true
+  become_method: sudo

--- a/ci/ansible/pulp_server_upgrade.yaml
+++ b/ci/ansible/pulp_server_upgrade.yaml
@@ -3,4 +3,5 @@
 - hosts: all
   roles:
     - role: pulp-upgrade
-  sudo: true
+  become: true
+  become_method: sudo

--- a/ci/ansible/pulp_smash.yaml
+++ b/ci/ansible/pulp_smash.yaml
@@ -3,4 +3,5 @@
 - hosts: all
   roles:
     - pulp-smash
-  sudo: true
+  become: true
+  become_method: sudo


### PR DESCRIPTION
Use `become` and `become_method` instead of `sudo` in playbooks. From
the Ansible docs:

> As of 1.9 *become* supersedes the old sudo/su, while still being
> backwards compatible.

See: http://docs.ansible.com/ansible/become.html