### PR TITLE
Pull the current pulp version from setup.py in pr tests

### DIFF
--- a/ci/jobs/unittests.yaml
+++ b/ci/jobs/unittests.yaml
@@ -69,8 +69,8 @@
 
             set -x
 
-            # get the base pulp version
-            PULP_VERSION=$(grep -Po "(^[\d]+\.[\d]+)" pulp/rel-eng/packages/pulp)
+            # get the base pulp version from the server setup.py
+            PULP_VERSION=$(python2 pulp/server/setup.py --version | grep -Po "([\d]+\.[\d]+)")
             echo "PULP BASE VERSION: ${PULP_VERSION}"
 
             if [ "$OS_NAME" == "RedHatEnterpriseServer" ]; then


### PR DESCRIPTION
We currently pull this from a file that tito drops into the source repo,
which confuses the PR tester on master because this file only gets updated
by tito when we do a release build. The spec file and setup.pys do get
updated regularly, though. Since the spec files are moving to the packaging
repo, it makes sense to ask the setup.py file what the current version is
and use that, rather than depend on a file made by tito after a release.