### PR TITLE
"Librarize" common git cloning code across scripts

### DIFF
--- a/ci/build-all.py
+++ b/ci/build-all.py
@@ -62,15 +62,11 @@ component_list = []
 spec_project_map = {}
 
 print "Getting git repos"
-for component in configuration['repositories']:
-    print "Cloning from github: %s" % component.get('git_url')
+for component in builder.components(configuration):
+    project_dir = builder.clone_branch(component)
     branch_name = component['git_branch']
     parent_branch = component.get('parent_branch', None)
-    command = ['git', 'clone', component.get('git_url'), '--branch', branch_name]
-    subprocess.call(command, cwd=working_dir)
-    parent_branch = component.get('parent_branch', None)
     parent_branches['origin/%s' % branch_name] = parent_branch
-    project_dir = os.path.join(working_dir, component['name'])
 
     # Check if this is a branch or a tag
     tag_exists = builder.does_git_tag_exist(branch_name, project_dir)
@@ -97,7 +93,7 @@ download_list = []
 build_list = []
 
 # Check for external deps
-for component in configuration['repositories']:
+for component in builder.components(configuration):
     external_deps_file = component.get('external_deps')
     if external_deps_file:
         external_deps_file = os.path.join(working_dir, component.get('name'), external_deps_file)

--- a/ci/lib/builder.py
+++ b/ci/lib/builder.py
@@ -112,6 +112,23 @@ MASH_DIR = os.path.join(WORKSPACE, 'mash')
 TITO_DIR = os.path.join(WORKSPACE, 'tito')
 CI_DIR = os.path.join(WORKSPACE, 'pulp_packaging', 'ci')
 
+
+def clone_branch(component):
+    """
+    Clone a git repository component into the working dir.
+
+    Assumes the working dir has already been created and cleaned, if needed, before cloning.
+
+    Returns the directory into which the branch was cloned.
+    """
+    print("Cloning from github: %s" % component['git_url'])
+    # --branch will let you check out tags as a detached head
+    command = ['git', 'clone', component['git_url'], '--branch',
+               component['git_branch'], component['name']]
+    subprocess.call(command, cwd=WORKING_DIR)
+    return os.path.join(WORKING_DIR, component['name'])
+
+
 def get_nvr_from_spec_file_in_directory(directory_path):
     """
     Find the first spec file in a directory and return the pacakge NVR from it
@@ -738,3 +755,7 @@ def load_config(config_name):
     with open(config_file, 'r') as config_handle:
         config = yaml.safe_load(config_handle)
     return config
+
+
+def components(configuration):
+    return configuration['repositories']

--- a/ci/update-version.py
+++ b/ci/update-version.py
@@ -1,231 +1,43 @@
 #!/usr/bin/env python
 import argparse
-import glob
 import os
-import re
-import shutil
 import sys
 
-try:
-    #py2
-    from StringIO import StringIO
-except ImportError:
-    #py3
-    from io import StringIO
+from lib import builder, promote
 
-from lib import builder
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("directory", help="The directory to search for spec files")
+    group = parser.add_mutually_exclusive_group(required=True)
+    help_text = ("Specify which part of the version is being updated. "
+                 "Whichever part is specified will udpate all the other parts in accordance "
+                 " with the version guildelines in the documentation. The version is "
+                 "structured as major.minor.patch-release.stage (2.6.3-0.1.alpha). "
+                 "If any part is updated the parts below it will be reset. "
+                 "stage update 2.6.0-1 -> 2.6.1-0.1.alpha "
+                 "stage update 2.6.1-0.3.alpha -> 2.6.1-0.4.beta"
+                 "stage update 2.6.1-0.5.rc -> 2.6.1-1"
+                 "patch update 2.6.1-1 -> 2.6.2-0.1.alpha")
+    group.add_argument("--update-type", choices=['major', 'minor', 'patch', 'release', 'stage'],
+                       help=help_text)
+    group.add_argument("--version", help="Manually set full version (eg. 2.6.2-0.1.alpha)")
 
-VERSION_REGEX = "(\s*)(version)(\s*)(=)(\s*)(['\"])(.*)(['\"])(.*)"
-RELEASE_REGEX = "(\s*)(release)(\s*)(=)(\s*)(['\"])(.*)(['\"])(.*)"
-
-def parse_version(version):
-    version_components = version.split('.')
-    major_version = 0
-    minor_version = 0
-    patch_version = 0
-    try:
-        major_version = int(version_components.pop(0))
-        minor_version = int(version_components.pop(0))
-        patch_version = int(version_components.pop(0))
-    except IndexError:
-        pass
-    return major_version, minor_version, patch_version
+    return parser.parse_args()
 
 
-def parse_release(release):
-    release_components = release.split('.')
-    major_release = 0
-    minor_release = None
-    stage = None
-    try:
-        major_release = int(release_components.pop(0))
-        minor_release = int(release_components.pop(0))
-        stage = release_components.pop(0)
-    except IndexError:
-        pass
-    return major_release, minor_release, stage
+if __name__ == '__main__':
+    opts = parse_args()
+    spec_file = promote.find_spec(opts.directory)
 
-
-def set_spec_version(spec_file, version, release):
-    version_regex = re.compile("^(version:\s*)(.+)$", re.IGNORECASE)
-    release_regex = re.compile("^(release:\s*)(.+)$", re.IGNORECASE)
-    in_f = open(spec_file, 'r')
-    out_f = open(spec_file + ".new", 'w')
-    for line in in_f.readlines():
-        match = re.match(version_regex, line)
-        if match:
-            line = "".join((match.group(1), version, "\n"))
-        match = re.match(release_regex, line)
-        if match:
-            line = "".join((match.group(1), release, "%{?dist}\n"))
-
-        out_f.write(line)
-
-    in_f.close()
-    out_f.close()
-    shutil.move(spec_file + ".new", spec_file)
-    print("updated %s to %s-%s" % (spec_file, version, release))
-
-
-def replace_version(line, new_version, regex):
-    """
-    COPIED FROM TITO
-
-    Attempts to replace common setup.py version formats in the given line,
-    and return the modified line. If no version is present the line is
-    returned as is.
-
-    Looking for things like version="x.y.z" with configurable case,
-    whitespace, and optional use of single/double quotes.
-    """
-    # Mmmmm pretty regex!
-    ver_regex = re.compile(regex, re.IGNORECASE)
-    m = ver_regex.match(line)
-    if m:
-        result_tuple = list(m.group(1, 2, 3, 4, 5, 6))
-        result_tuple.append(new_version)
-        result_tuple.extend(list(m.group(8, 9)))
-        new_line = "%s%s%s%s%s%s%s%s%s\n" % tuple(result_tuple)
-        return new_line
+    # version and update_type are mutually exclusive and required
+    # if one is not set, the other must be
+    if opts.version:
+        # user specified version so get it from there
+        version, release = opts.version.split('-')
     else:
-        return line
+        # otherwise, pull it from the spec and update according to update type
+        spec_version = builder.get_version_from_spec(spec_file)
+        spec_release = builder.get_release_from_spec(spec_file)
+        version, release = promote.calculate_version(spec_version, spec_release, opts.update_type)
 
-
-def find_replace_in_files(root_directory, file_mask, new_version, version_regex):
-    # We also have to check the __init__.py files since that is the more pythonic place to put it
-    for file_name in builder.find_files_matching_pattern(root_directory, file_mask):
-        f = open(file_name, 'r')
-        buf = StringIO()
-        for line in f.readlines():
-            new_line = replace_version(line, new_version, version_regex)
-            if new_line != line:
-                print("updated %s: to %s" % (file_name, new_version))
-            buf.write(new_line)
-        f.close()
-
-        # Write out the new setup.py file contents:
-        f = open(file_name, 'w')
-        f.write(buf.getvalue())
-        f.close()
-        buf.close()
-
-
-parser = argparse.ArgumentParser()
-parser.add_argument("directory", help="The directory to search for spec files")
-group = parser.add_mutually_exclusive_group(required=True)
-help_text = "Specify which part of the version is being updated. "\
-            "Whichever part is specified will udpate all the other parts in accordance"\
-            " with the version guildelines in the documentation. The version is "\
-            "structured as major.minor.patch-release.stage (2.6.3-0.1.alpha)."\
-            "If any part is updated the parts below it will be reset. "\
-            "stage update 2.6.0-1 -> 2.6.1-0.1.alpha "\
-            "stage update 2.6.1-0.3.alpha -> 2.6.1-0.4.beta"\
-            "stage update 2.6.1-0.5.rc -> 2.6.1-1"\
-            "patch update 2.6.1-1 -> 2.6.2-0.1.alpha"
-group.add_argument("--update-type", choices=['major', 'minor', 'patch', 'release', 'stage'],
-                   help=help_text)
-group.add_argument("--version", help="Manually set full version (eg. 2.6.2-0.1.alpha)")
-
-opts = parser.parse_args()
-
-# Find the spec
-spec_files = glob.glob(os.path.join(opts.directory, '*.spec'))
-if not spec_files:
-    print("Error, unable to find spec file in %s " % opts.directory)
-    sys.exit(1)
-
-spec_file = spec_files[0]
-
-# Get the components of the current version
-if opts.update_type:
-    full_version = builder.get_version_from_spec(spec_file)
-    full_release = builder.get_release_from_spec(spec_file)
-else:
-    # user specified version so get it from there
-    full_version, full_release = opts.version.split('-')
-
-# print(full_version)
-# print(full_release)
-
-
-major_version, minor_version, patch_version = parse_version(full_version)
-major_release, minor_release, stage = parse_release(full_release)
-
-update_type = None
-if opts.update_type:
-    update_type = opts.update_type
-
-# print([major_release, major_release, stage])
-
-if update_type == 'major':
-    major_version += 1
-    minor_version = 0
-    patch_version = 0
-    major_release = 0
-    minor_release = 1
-    stage = 'alpha'
-elif update_type == 'minor':
-    minor_version += 1
-    patch_version = 0
-    major_release = 0
-    minor_release = 1
-    stage = 'alpha'
-elif update_type == 'patch':
-    patch_version += 1
-    major_release = 0
-    minor_release = 1
-    stage = 'alpha'
-elif update_type == 'release':
-    if minor_release is None:
-        major_release += 1
-        minor_release = 1
-        stage = 'alpha'
-    else:
-        minor_release += 1
-elif update_type == 'stage':
-    if stage is None:
-        patch_version += 1
-        major_release += 1
-        minor_release = 1
-        stage = 'alpha'
-    elif stage == 'alpha':
-        stage = 'beta'
-        minor_release += 1
-    elif stage == 'beta':
-        stage = 'rc'
-        minor_release += 1
-    elif stage == 'rc':
-        stage = None
-        minor_release = None
-        major_release += 1
-
-
-calculated_version = "%s.%s.%s" % (major_version, minor_version, patch_version)
-
-calculated_release = "%s" % major_release
-# print([major_release, minor_release, stage])
-if minor_release is not None:
-    calculated_release += '.%s' % minor_release
-if stage is not None:
-    calculated_release += '.%s' % stage
-
-if patch_version > 0:
-    python_version = calculated_version
-else:
-    python_version = "%d.%d" % (major_version, minor_version)
-if stage in ('alpha', 'beta', 'rc'):
-    if stage == 'alpha':
-        python_version += 'a'
-    elif stage == 'beta':
-        python_version += 'b'
-    elif stage == 'rc':
-        python_version += 'c'
-    python_version += '%s' % minor_release
-
-# Update the all the files
-set_spec_version(spec_file, calculated_version, calculated_release)
-find_replace_in_files(os.path.dirname(spec_file), 'setup.py', python_version, VERSION_REGEX)
-find_replace_in_files(os.path.dirname(spec_file), '__init__.py', python_version, VERSION_REGEX)
-
-find_replace_in_files(os.path.dirname(spec_file), 'conf.py', python_version, VERSION_REGEX)
-find_replace_in_files(os.path.dirname(spec_file), 'conf.py', python_version, RELEASE_REGEX)
+    promote.update_versions(spec_file, version, release)


### PR DESCRIPTION
Both the merge forward script and build-all have had duplicated
code for a while. The introduction of docs-builder came with a
third place where git cloning was done. I put in a hacky fix in
centralizing the git cloning and update code.

This is that follow-up. :)

The diff is, I think, a case of "It looks worse than it is." The
basic plan I followed was to functionalize behaviors, and then move
any function that isn't "parse_args", "main", etc. up into the lib
modules to be shared by the multiple scripts that want to use them.

To test, build-all, docs-builder, and the update-version-and-merge-forward
scripts should all work as expected, and definitely not explode.