### PR TITLE
Build scripts filter out unsupported dists by default

### DIFF
--- a/ci/jobs/build-automation.yaml
+++ b/ci/jobs/build-automation.yaml
@@ -65,7 +65,9 @@
             if [ $RELEASE_BUILD == true ] ; then
               ./build-all.py {release_config} --release
             else
-              ./build-all.py {release_config}
+              # include unsupported dists in nightlies; this should highlight when dist_lists need to be
+              # updated, and also provides continued testing of el6 nightly and in PRs
+              ./build-all.py {release_config} --build-unsupported
             fi
     publishers:
       - join-trigger:

--- a/ci/lib/promote.py
+++ b/ci/lib/promote.py
@@ -249,6 +249,13 @@ def merge_forward(git_directory, push=False, parent_branch=None):
     checkout_branch(git_directory, starting_branch)
 
 
+def split_version(evr):
+    """
+    split epoch:version-release into (epoch:version, release)
+    """
+    return evr.rsplit('-', 1)
+
+
 def parse_version(version):
     version_components = version.split('.')
     major_version = 0
@@ -417,10 +424,14 @@ def calculate_version(full_version, full_release, update_type):
     return calculated_version, calculated_release
 
 
-def to_python_version(version, release):
+def to_python_version(version, release=None):
     """
     convert an rpm-style version and release into a python version string
+
+    can split a complete rpm version-release string, if release is not passed
     """
+    if release is None:
+        version, release = split_version(version)
     major_version, minor_version, patch_version = parse_version(version)
     major_release, minor_release, stage = parse_release(release)
 

--- a/ci/update-version.py
+++ b/ci/update-version.py
@@ -33,7 +33,7 @@ if __name__ == '__main__':
     # if one is not set, the other must be
     if opts.version:
         # user specified version so get it from there
-        version, release = opts.version.split('-')
+        version, release = promote.split_version(opts.version)
     else:
         # otherwise, pull it from the spec and update according to update type
         spec_version = builder.get_version_from_spec(spec_file)


### PR DESCRIPTION
With the changes to our support policy, it's become necessary for
release engineering sanity to bake the idea of supported distributions
into the build scripts and related libraries.

Since we still want nightlies and the PR tester to give us feedback if
something we do needlessly breaks el6, the nightly build job has been
updated to include unsupported distributions when building packages.

This commit is also peppered with linting, as well as more preparatory
work getting us ready to switch to python3 when building pulp (mainly
because we can, and the work is largely already done).

closes #2576
https://pulp.plan.io/issues/2576