### PR TITLE
Rewrite task to use iptables module

### DIFF
--- a/ci/ansible/roles/pulp/tasks/main.yaml
+++ b/ci/ansible/roles/pulp/tasks/main.yaml
@@ -5,7 +5,13 @@
     that: ansible_os_family == "RedHat"
 
 - name: Open firewall ports
-  shell: "iptables -I INPUT -m state --state NEW -p tcp --dport {{ item }} -j ACCEPT"
+  iptables:
+    action: insert
+    chain: INPUT
+    ctstate: NEW
+    protocol: tcp
+    destination_port: "{{ item }}"
+    jump: ACCEPT
   with_items:
     - 80
     - 443


### PR DESCRIPTION
Rewrite a task to use the "iptables" Ansible module instead of the
"shell" ansible module. This ensures that changes are only made when
necessary.