### PR TITLE
Update path to python-qpid{,-common}

### DIFF
--- a/ci/ansible/roles/pulp/tasks/pulp_server.yaml
+++ b/ci/ansible/roles/pulp/tasks/pulp_server.yaml
@@ -32,8 +32,8 @@
 - name: Install testing qpid RHEL7 packages
   shell: >
       rpm -Uvh
-      https://kojipkgs.fedoraproject.org//packages/python-qpid/1.35.0/2.el7/noarch/python-qpid-common-1.35.0-2.el7.noarch.rpm
-      https://kojipkgs.fedoraproject.org//packages/python-qpid/1.35.0/2.el7/noarch/python-qpid-1.35.0-2.el7.noarch.rpm
+      https://kojipkgs.fedoraproject.org/packages/python-qpid/1.35.0/1.el7/noarch/python-qpid-common-1.35.0-1.el7.noarch.rpm
+      https://kojipkgs.fedoraproject.org/packages/python-qpid/1.35.0/1.el7/noarch/python-qpid-1.35.0-1.el7.noarch.rpm
   when: ansible_distribution == "RedHat" and ansible_distribution_major_version|int == 7
 
 - name: Start and enable qpid-cpp server service


### PR DESCRIPTION
URLs to python-qpid{,-common} packages are hard-coded into the Ansible
configuration file. The given URLs are broken - they point to
non-existent files, and servers correctly return HTTP 404 responses when
asked for those files. Update the URLs.