### PR TITLE
Save IPv4 iptables firewall if modified

### DIFF
--- a/ci/ansible/roles/pulp/handlers/main.yaml
+++ b/ci/ansible/roles/pulp/handlers/main.yaml
@@ -24,3 +24,6 @@
   service:
     name: goferd
     state: restarted
+
+- name: Save IPv4 iptables configuration
+  shell: 'iptables-save > /etc/sysconfig/iptables'

--- a/ci/ansible/roles/pulp/tasks/main.yaml
+++ b/ci/ansible/roles/pulp/tasks/main.yaml
@@ -18,6 +18,8 @@
     - 5672
     - 5671
   when: pulp_install_prerequisites
+  notify:
+    - Save IPv4 iptables configuration
 
 # De-registering and then registering is equivalent to using the
 # `force_register` argument, which was added in Ansible 2.2. We use this


### PR DESCRIPTION
This change ensures that changes to the firewall persist across reboots.