### PR TITLE
Use RHN Pool name instead of Pool ID

### DIFF
--- a/ci/ansible/roles/pulp/tasks/main.yaml
+++ b/ci/ansible/roles/pulp/tasks/main.yaml
@@ -29,7 +29,7 @@
     state: absent
   when: >
     ansible_distribution == "RedHat" and
-    rhn_poolid is defined and
+    rhn_pool is defined and
     (rhn_username is defined and rhn_password is defined) or
     (rhn_activation_key is defined and rhn_organization is defined)
 
@@ -37,10 +37,10 @@
   redhat_subscription:
     username: "{{ rhn_username }}"
     password: "{{ rhn_password }}"
-    pool: "{{ rhn_poolid }}"  # e.g. rhn_poolid='^SKU Name$'
+    pool: "{{ rhn_pool }}"  # e.g. rhn_pool='^SKU Name$'
   when:
     - ansible_distribution == "RedHat"
-    - rhn_poolid is defined
+    - rhn_pool is defined
     - rhn_username is defined
     - rhn_password is defined
     - rhn_activation_key is undefined
@@ -50,10 +50,10 @@
   redhat_subscription:
     activationkey: "{{ rhn_activation_key }}"
     org_id: "{{ rhn_organization }}"
-    pool: "{{ rhn_poolid }}"
+    pool: "{{ rhn_pool }}"
   when:
     - ansible_distribution == "RedHat"
-    - rhn_poolid is defined
+    - rhn_pool is defined
     - rhn_username is undefined
     - rhn_password is undefined
     - rhn_activation_key is defined

--- a/ci/jobs/pulp-dev.yaml
+++ b/ci/jobs/pulp-dev.yaml
@@ -29,7 +29,7 @@
                 -e pulp_version={pulp_version} \
                 -e "rhn_username=${{RHN_USERNAME}}" \
                 -e "rhn_password=${{RHN_PASSWORD}}" \
-                -e "rhn_poolid=${{RHN_POOLID}}"
+                -e "rhn_pool=${{RHN_POOL}}"
             if [ "$(echo -e 2.8\\n${{PULP_VERSION}} | sort -V | head -n 1)" = "2.8" ] && [ "${{OS}}" != "rhel6" ]; then
                 ansible-playbook --connection local -i hosts ci/ansible/pulp_coverage.yaml
             fi

--- a/ci/jobs/pulp-installer.yaml
+++ b/ci/jobs/pulp-installer.yaml
@@ -60,7 +60,7 @@
                 -e "pulp_version=${PULP_VERSION}" \
                 -e "rhn_username=${RHN_USERNAME}" \
                 -e "rhn_password=${RHN_PASSWORD}" \
-                -e "rhn_poolid=${RHN_POOLID}"
+                -e "rhn_pool=${RHN_POOL}"
     publishers:
         - email-notify-owners
         - mark-node-offline

--- a/ci/jobs/pulp-upgrade.yaml
+++ b/ci/jobs/pulp-upgrade.yaml
@@ -47,7 +47,7 @@
                 -e pulp_version=${{PULP_VERSION}} \
                 -e "rhn_username=${{RHN_USERNAME}}" \
                 -e "rhn_password=${{RHN_PASSWORD}}" \
-                -e "rhn_poolid=${{RHN_POOLID}}"
+                -e "rhn_pool=${{RHN_POOL}}"
         - shell:
             !include-raw-escape: pre-upgrade.sh
         - shell: |


### PR DESCRIPTION
Revert the changes so the ansible playbook uses the rhn_playbook
variable and update the job definition to proper pass that renamed
parameter.