### PR TITLE
Problem: external_bugs missing with python-bugzilla 2.0.0

### DIFF
--- a/ci/jobs/redmine.yaml
+++ b/ci/jobs/redmine.yaml
@@ -37,7 +37,7 @@
 
             cd $WORKSPACE/
 
-            sudo pip install --upgrade 'python-bugzilla<2.0.0'
+            sudo pip install --upgrade python-bugzilla
             sudo pip install python-redmine
             sudo pip install certifi
 

--- a/ci/redmine_bugzilla.py
+++ b/ci/redmine_bugzilla.py
@@ -114,7 +114,9 @@ def main():
         'columnlist=priority%2Cbug_severity%2Cbug_status%2Cshort_desc%2Cchangeddate%2C' \
         'component%2Ctarget_release%2Cassigned_to%2Creporter&f1=external_bugzilla.url&' \
         'list_id=3309842&o1=substring&query_format=advanced&v1=pulp.plan.io'
-    bugzilla_bugs = BZ.query(RHBugzilla.url_to_query(non_closed_bug_with_ext_tracker))
+    query = BZ.url_to_query(non_closed_bug_with_ext_tracker)
+    query["extra_fields"] = ["external_bugs"]
+    bugzilla_bugs = BZ.query(query)
 
     links_issues_record = ''
     ext_bug_record = ''


### PR DESCRIPTION
Solution: explicitly tell bugzilla query to fetch external_bugs field