### PR TITLE
Move duplicated code to external scripts

### DIFF
--- a/ci/jobs/pulp-dev.yaml
+++ b/ci/jobs/pulp-dev.yaml
@@ -13,34 +13,18 @@
         - inject:
             properties-content: |
                 OS={os}
+                PULP_BUILD=nightly
                 PULP_VERSION={pulp_version}
     triggers:
         - reverse:
             jobs: 'build-automation-repo-{reverse_trigger}'
             result: 'success'
     builders:
-        - shell: |
-            sudo yum -y install ansible attr git libselinux-python
-            ssh-keygen -t rsa -N "" -f pulp_server_key
-            cat pulp_server_key.pub >> ~/.ssh/authorized_keys
-            echo 'localhost' > hosts
-            source ${{RHN_CREDENTIALS}}
-            ansible-playbook --connection local -i hosts ci/ansible/pulp_server.yaml \
-                -e pulp_version={pulp_version} \
-                -e "rhn_username=${{RHN_USERNAME}}" \
-                -e "rhn_password=${{RHN_PASSWORD}}" \
-                -e "rhn_pool=${{RHN_POOL}}"
-            if [ "$(echo -e 2.8\\n${{PULP_VERSION}} | sort -V | head -n 1)" = "2.8" ] && [ "${{OS}}" != "rhel6" ]; then
-                ansible-playbook --connection local -i hosts ci/ansible/pulp_coverage.yaml
-            fi
-            echo "BASE_URL=https://$(hostname --long)" >> parameters.txt
-            PULP_RPM_VERSION="$(rpm -qa pulp-server | cut -d- -f3)"
-            if [ "${{PULP_VERSION}}" != "$(cut -d. -f-2 <<< ${{PULP_RPM_VERSION}})" ]; then
-                echo "Pulp RPM version ${{PULP_RPM_VERSION}} is not in the ${{PULP_VERSION}} series"
-                exit 1
-            fi
-            echo "PULP_VERSION=${{PULP_RPM_VERSION}}" >> parameters.txt
-            cp /etc/pki/CA/cacert.pem cacert.pem
+        - shell:
+            !include-raw-escape:
+                - 'pulp-install.sh'
+                - 'pulp-coverage-setup.sh'
+                - 'pulp-smash-parameters.sh'
         - inject:
             properties-file: parameters.txt
         - trigger-builds:

--- a/ci/jobs/pulp-upgrade.yaml
+++ b/ci/jobs/pulp-upgrade.yaml
@@ -35,36 +35,18 @@
             echo "UPGRADE_PULP_BUILD=$(cut -d- -f2 <<< ${{UPGRADE_PULP_VERSION}})" >> pulp_version.properties
         - inject:
             properties-file: pulp_version.properties
-        - shell: |
-            sudo yum -y install ansible attr git libselinux-python
-            ssh-keygen -t rsa -N "" -f pulp_server_key
-            cat pulp_server_key.pub >> ~/.ssh/authorized_keys
-            export ANSIBLE_HOST_KEY_CHECKING=False
-            echo 'localhost' > hosts
-            source "${{RHN_CREDENTIALS}}"
-            ansible-playbook --connection local -i hosts ci/ansible/pulp_server.yaml \
-                -e pulp_build=${{PULP_BUILD}} \
-                -e pulp_version=${{PULP_VERSION}} \
-                -e "rhn_username=${{RHN_USERNAME}}" \
-                -e "rhn_password=${{RHN_PASSWORD}}" \
-                -e "rhn_pool=${{RHN_POOL}}"
         - shell:
-            !include-raw-escape: pre-upgrade.sh
+            !include-raw-escape:
+                - 'pulp-install.sh'
+                - 'pre-upgrade.sh'
         - shell: |
             ansible-playbook --connection local -i hosts ci/ansible/pulp_server_upgrade.yaml \
                 -e "upgrade_pulp_build=${{UPGRADE_PULP_BUILD}}" \
                 -e "upgrade_pulp_version=${{UPGRADE_PULP_VERSION}}"
         - shell:
-            !include-raw-escape: post-upgrade.sh
-        - shell: |
-            echo "BASE_URL=https://$(hostname --long)" > parameters.txt
-            PULP_RPM_VERSION="$(rpm -qa pulp-server | cut -d- -f3)"
-            if [ "${{UPGRADE_PULP_VERSION}}" != "$(cut -d. -f-2 <<< ${{PULP_RPM_VERSION}})" ]; then
-                echo "Pulp RPM version ${{PULP_RPM_VERSION}} is not in the ${{PULP_VERSION}} series"
-                exit 1
-            fi
-            echo "UPGRADE_PULP_VERSION=${{PULP_RPM_VERSION}}" >> parameters.txt
-            cp /etc/pki/CA/cacert.pem cacert.pem
+            !include-raw-escape:
+                - 'post-upgrade.sh'
+                - 'pulp-smash-parameters.sh'
         - inject:
             properties-file: parameters.txt
         - trigger-builds:

--- a/ci/jobs/scripts/pulp-coverage-setup.sh
+++ b/ci/jobs/scripts/pulp-coverage-setup.sh
@@ -1,0 +1,3 @@
+if [ "$(echo -e 2.8\\n"${PULP_VERSION}" | sort -V | head -n 1)" = "2.8" ] && [ "${OS}" != "rhel6" ]; then
+    ansible-playbook --connection local -i hosts ci/ansible/pulp_coverage.yaml
+fi

--- a/ci/jobs/scripts/pulp-install.sh
+++ b/ci/jobs/scripts/pulp-install.sh
@@ -1,0 +1,11 @@
+sudo yum -y install ansible attr git libselinux-python
+ssh-keygen -t rsa -N "" -f pulp_server_key
+cat pulp_server_key.pub >> ~/.ssh/authorized_keys
+echo 'localhost' > hosts
+source "${RHN_CREDENTIALS}"
+ansible-playbook --connection local -i hosts ci/ansible/pulp_server.yaml \
+    -e "pulp_build=${PULP_BUILD}" \
+    -e "pulp_version=${PULP_VERSION}" \
+    -e "rhn_password=${RHN_PASSWORD}" \
+    -e "rhn_pool=${RHN_POOL}" \
+    -e "rhn_username=${RHN_USERNAME}"

--- a/ci/jobs/scripts/pulp-smash-parameters.sh
+++ b/ci/jobs/scripts/pulp-smash-parameters.sh
@@ -1,0 +1,8 @@
+echo "BASE_URL=https://$(hostname --long)" > parameters.txt
+PULP_RPM_VERSION="$(rpm -qa pulp-server | cut -d- -f3)"
+if [ "${PULP_VERSION}" != "$(cut -d. -f-2 <<< "${PULP_RPM_VERSION}")" ]; then
+    echo "Pulp RPM version ${PULP_RPM_VERSION} is not in the ${PULP_VERSION} series"
+    exit 1
+fi
+echo "PULP_VERSION=${PULP_RPM_VERSION}" >> parameters.txt
+cp /etc/pki/CA/cacert.pem cacert.pem


### PR DESCRIPTION
Create scripts for the Pulp Automation and Pulp Upgrade Automation in
order to reuse code. This will allow future jobs to include those files
whenever the functionalities are needed.