### PR TITLE
Create ssh-setup.sh script

### DIFF
--- a/ci/jobs/pulp-dev.yaml
+++ b/ci/jobs/pulp-dev.yaml
@@ -22,6 +22,7 @@
     builders:
         - shell:
             !include-raw-escape:
+                - 'ssh-setup.sh'
                 - 'pulp-install.sh'
                 - 'pulp-coverage-setup.sh'
                 - 'pulp-smash-parameters.sh'

--- a/ci/jobs/pulp-upgrade.yaml
+++ b/ci/jobs/pulp-upgrade.yaml
@@ -37,6 +37,7 @@
             properties-file: pulp_version.properties
         - shell:
             !include-raw-escape:
+                - 'ssh-setup.sh'
                 - 'pulp-install.sh'
                 - 'pre-upgrade.sh'
         - shell: |

--- a/ci/jobs/scripts/pulp-install.sh
+++ b/ci/jobs/scripts/pulp-install.sh
@@ -1,6 +1,4 @@
 sudo yum -y install ansible attr git libselinux-python
-ssh-keygen -t rsa -N "" -f pulp_server_key
-cat pulp_server_key.pub >> ~/.ssh/authorized_keys
 echo 'localhost' > hosts
 source "${RHN_CREDENTIALS}"
 ansible-playbook --connection local -i hosts ci/ansible/pulp_server.yaml \

--- a/ci/jobs/scripts/ssh-setup.sh
+++ b/ci/jobs/scripts/ssh-setup.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ssh-keygen -t rsa -N "" -f pulp_server_key
+cat pulp_server_key.pub >> ~/.ssh/authorized_keys


### PR DESCRIPTION
Remove the SSH setup from the pulp-install.sh script and create a
dedicated script for that.

Having the ssh setup on a external script will help jobs like the pulp-clustered (under development) to provide its own ssh-setup logic. 