### PR TITLE
Use firewalld instead of iptables on most systems

### DIFF
--- a/ci/ansible/roles/pulp/tasks/main.yaml
+++ b/ci/ansible/roles/pulp/tasks/main.yaml
@@ -4,7 +4,7 @@
   assert:
     that: ansible_os_family == "RedHat"
 
-- name: Open firewall ports
+- name: Open firewall ports (iptables)
   iptables:
     action: insert
     chain: INPUT
@@ -17,9 +17,26 @@
     - 443
     - 5672
     - 5671
-  when: pulp_install_prerequisites
+  when:
+    - pulp_install_prerequisites
+    - ansible_distribution == "RedHat" and ansible_distribution_major_version|int == 6
   notify:
     - Save IPv4 iptables configuration
+
+- name: Open firewall ports (firewalld)
+  firewalld:
+    port: "{{ item }}/tcp"
+    state: enabled
+    permanent: true
+    immediate: true
+  with_items:
+    - 80
+    - 443
+    - 5672
+    - 5671
+  when:
+    - pulp_install_prerequisites
+    - not (ansible_distribution == "RedHat" and ansible_distribution_major_version|int == 6)
 
 # De-registering and then registering is equivalent to using the
 # `force_register` argument, which was added in Ansible 2.2. We use this

--- a/ci/jobs/scripts/pulp-install.sh
+++ b/ci/jobs/scripts/pulp-install.sh
@@ -1,4 +1,4 @@
-sudo yum -y install ansible attr git libselinux-python
+sudo yum -y install ansible attr git libselinux-python python-firewall
 echo 'localhost' > hosts
 source "${RHN_CREDENTIALS}"
 ansible-playbook --connection local -i hosts ci/ansible/pulp_server.yaml \


### PR DESCRIPTION
The primary IPv4 firewall configuration tool on RHEL 6 is iptables. The
primary IPv4 firewall configuration tool on RHEL 7, Fedora 24 and Fedora
25 is firewalld. Update the Ansible roles for installing Pulp so that
firewalld is used in most cases, and add "python-firewalld" as a
dependency. The upshot is that firewall rules fore these distributions
are now persistent across system and service restarts.