### PR TITLE
Install firewalld before trying to update firewall rules

### DIFF
--- a/ci/jobs/scripts/pulp-install.sh
+++ b/ci/jobs/scripts/pulp-install.sh
@@ -1,4 +1,4 @@
-sudo yum -y install ansible attr git libselinux-python python-firewall
+sudo yum -y install ansible attr git libselinux-python firewalld python-firewall
 echo 'localhost' > hosts
 source "${RHN_CREDENTIALS}"
 ansible-playbook --connection local -i hosts ci/ansible/pulp_server.yaml \


### PR DESCRIPTION
Recent builds on fedora are failing because the iptables step attempts
to use firewalld's python bindings to update the firewall and fails
because firewalld is missing.