### PR TITLE
Problem: script fails to set needinfo flag on bugzillas

### DIFF
--- a/ci/redmine_bugzilla.py
+++ b/ci/redmine_bugzilla.py
@@ -200,10 +200,12 @@ def main():
                                                             flag['requestee'] == needinfo_email:
                                                 needinfo = False
                                         if needinfo:
-                                            BZ.update_flags(bug.id, [{ "name": "needinfo",
-                                                                       "status": "?",
-                                                                       "requestee": needinfo_email,
-                                                                       "new": True}])
+                                            flag = { "name": "needinfo",
+                                                     "status": "?",
+                                                     "requestee": needinfo_email,
+                                                     "new": True}
+                                            updates = BZ.build_update(status=bug.status, flags = [flag])
+                                            BZ.update_bugs(bug.id, updates)
                                             bug.addcomment("Requesting needsinfo from upstream " \
                                                            "developer %s because the 'FailedQA' " \
                                                            "flag is set." % needinfo_email)


### PR DESCRIPTION
Solution: update script to use the 2.0 python-bugzilla API for setting
needinfo flag.