### PR TITLE
Install fedpkg before generating fixtures

### DIFF
--- a/ci/jobs/pulp-fixtures-publisher.yaml
+++ b/ci/jobs/pulp-fixtures-publisher.yaml
@@ -18,7 +18,7 @@
         - jenkins-ssh-credentials
     builders:
         - shell: |
-            sudo dnf -y install createrepo make patch puppet rpm-sign gpg
+            sudo dnf -y install createrepo make patch puppet rpm-sign gpg fedpkg
             make fixtures base_url=https://repos.fedorapeople.org/pulp/pulp
             rsync -arvze "ssh -o StrictHostKeyChecking=no" --delete \
                 fixtures/* \


### PR DESCRIPTION
This is needed for the new `fixtures/rpm-with-non-ascii` and
`fixtures/rpm-with-non-utf-8` make targets.