### PR TITLE
Update upgrade jobs permutations

### DIFF
--- a/ci/jobs/projects.yaml
+++ b/ci/jobs/projects.yaml
@@ -67,6 +67,7 @@
     name: pulp-upgrade
     os:
         - f24
+        - f25
         - rhel6
         - rhel7
     pulp_version:
@@ -99,6 +100,12 @@
           pulp_version: 2.8-stable
         - os: f24
           pulp_version: 2.9-stable
+        - os: f25
+          pulp_version: 2.8-stable
+        - os: f25
+          pulp_version: 2.9-stable
+        - os: f25
+          pulp_version: 2.10-stable
     jobs:
         - 'pulp-upgrade-{pulp_version}-{upgrade_pulp_version}-{os}'
 


### PR DESCRIPTION
Add Fedora 25 to the list or OSes and make sure to exclude Pulp versions
that are not available on Fedora 25.

This is the current list of generated jobs:

```
pulp-upgrade-2.8-stable-2.10-beta-rhel6
pulp-upgrade-2.8-stable-2.10-beta-rhel7
pulp-upgrade-2.8-stable-2.10-nightly-rhel6
pulp-upgrade-2.8-stable-2.10-nightly-rhel7
pulp-upgrade-2.8-stable-2.11-beta-rhel6
pulp-upgrade-2.8-stable-2.11-beta-rhel7
pulp-upgrade-2.8-stable-2.11-nightly-rhel6
pulp-upgrade-2.8-stable-2.11-nightly-rhel7
pulp-upgrade-2.8-stable-2.12-beta-rhel6
pulp-upgrade-2.8-stable-2.12-beta-rhel7
pulp-upgrade-2.8-stable-2.12-nightly-rhel6
pulp-upgrade-2.8-stable-2.12-nightly-rhel7
pulp-upgrade-2.9-stable-2.10-beta-rhel6
pulp-upgrade-2.9-stable-2.10-beta-rhel7
pulp-upgrade-2.9-stable-2.10-nightly-rhel6
pulp-upgrade-2.9-stable-2.10-nightly-rhel7
pulp-upgrade-2.9-stable-2.11-beta-rhel6
pulp-upgrade-2.9-stable-2.11-beta-rhel7
pulp-upgrade-2.9-stable-2.11-nightly-rhel6
pulp-upgrade-2.9-stable-2.11-nightly-rhel7
pulp-upgrade-2.9-stable-2.12-beta-rhel6
pulp-upgrade-2.9-stable-2.12-beta-rhel7
pulp-upgrade-2.9-stable-2.12-nightly-rhel6
pulp-upgrade-2.9-stable-2.12-nightly-rhel7
pulp-upgrade-2.10-stable-2.10-beta-f24
pulp-upgrade-2.10-stable-2.10-beta-rhel6
pulp-upgrade-2.10-stable-2.10-beta-rhel7
pulp-upgrade-2.10-stable-2.10-nightly-f24
pulp-upgrade-2.10-stable-2.10-nightly-rhel6
pulp-upgrade-2.10-stable-2.10-nightly-rhel7
pulp-upgrade-2.10-stable-2.11-beta-f24
pulp-upgrade-2.10-stable-2.11-beta-rhel6
pulp-upgrade-2.10-stable-2.11-beta-rhel7
pulp-upgrade-2.10-stable-2.11-nightly-f24
pulp-upgrade-2.10-stable-2.11-nightly-rhel6
pulp-upgrade-2.10-stable-2.11-nightly-rhel7
pulp-upgrade-2.10-stable-2.12-beta-f24
pulp-upgrade-2.10-stable-2.12-beta-rhel6
pulp-upgrade-2.10-stable-2.12-beta-rhel7
pulp-upgrade-2.10-stable-2.12-nightly-f24
pulp-upgrade-2.10-stable-2.12-nightly-rhel6
pulp-upgrade-2.10-stable-2.12-nightly-rhel7
pulp-upgrade-2.11-stable-2.11-beta-f24
pulp-upgrade-2.11-stable-2.11-beta-f25
pulp-upgrade-2.11-stable-2.11-beta-rhel6
pulp-upgrade-2.11-stable-2.11-beta-rhel7
pulp-upgrade-2.11-stable-2.11-nightly-f24
pulp-upgrade-2.11-stable-2.11-nightly-f25
pulp-upgrade-2.11-stable-2.11-nightly-rhel6
pulp-upgrade-2.11-stable-2.11-nightly-rhel7
pulp-upgrade-2.11-stable-2.12-beta-f24
pulp-upgrade-2.11-stable-2.12-beta-f25
pulp-upgrade-2.11-stable-2.12-beta-rhel6
pulp-upgrade-2.11-stable-2.12-beta-rhel7
pulp-upgrade-2.11-stable-2.12-nightly-f24
pulp-upgrade-2.11-stable-2.12-nightly-f25
pulp-upgrade-2.11-stable-2.12-nightly-rhel6
pulp-upgrade-2.11-stable-2.12-nightly-rhel7
pulp-upgrade-2.12-stable-2.12-beta-f24
pulp-upgrade-2.12-stable-2.12-beta-f25
pulp-upgrade-2.12-stable-2.12-beta-rhel6
pulp-upgrade-2.12-stable-2.12-beta-rhel7
pulp-upgrade-2.12-stable-2.12-nightly-f24
pulp-upgrade-2.12-stable-2.12-nightly-f25
pulp-upgrade-2.12-stable-2.12-nightly-rhel6
pulp-upgrade-2.12-stable-2.12-nightly-rhel7
```