### PR TITLE
Jenkins Job Tweaks

### DIFF
--- a/ci/jobs/build-automation.yaml
+++ b/ci/jobs/build-automation.yaml
@@ -35,6 +35,7 @@
             timeout: 240
             timeout-var: 'BUILD_TIMEOUT'
             fail: true
+        - timestamps
     builders:
         - shell: |
             #!/bin/bash

--- a/ci/jobs/defaults.yaml
+++ b/ci/jobs/defaults.yaml
@@ -17,3 +17,4 @@
         numToKeep: 30
     wrappers:
         - default-ci-workflow-wrappers
+        - timestamps

--- a/ci/jobs/macros.yaml
+++ b/ci/jobs/macros.yaml
@@ -205,9 +205,17 @@
             timeout-var: 'BUILD_TIMEOUT'
             fail: true
 
+# ssh credentials common to multiple jobs
+# normally we would want to capture this in multiple macros, but using the ssh-agent-credentials
+# multiple times in a job does not work; all previous invocations get overriden by the last one
+# processed. For convenience, the most commonly use SSH credentials are defined here.
 - wrapper:
     name: jenkins-ssh-credentials
     wrappers:
         - ssh-agent-credentials:
             users:
+              # used by the master to connect to slaves, also allows slave to ssh into other slaves,
+              # and connect to our automation VM to retrieve logs for posting in a public place
                 - '044c0620-d67e-4172-9814-dc49e443e7b6'
+              # fedorapeople ssh key, allows jenkins to upload built packages and logs publicly
+                - '90b7ff7d-de7f-4ccb-93e7-fa27409913ec'

--- a/ci/jobs/pulp-dev.yaml
+++ b/ci/jobs/pulp-dev.yaml
@@ -170,7 +170,7 @@
             }
             EOF
             set +e
-            XDG_CONFIG_DIRS=. py.test -v --junit-xml=junit-report.xml pulp_smash/tests
+            XDG_CONFIG_DIRS=. py.test -v --color=yes --junit-xml=junit-report.xml pulp_smash/tests
             set -e
             test -f junit-report.xml
     publishers:

--- a/ci/jobs/sync.yaml
+++ b/ci/jobs/sync.yaml
@@ -7,12 +7,14 @@
           H H * * *
           31 11 * * 2,5
     wrappers:
+      - workspace-cleanup:
+          dirmatch: True
+          include: ['*']
       - jenkins-ssh-credentials
     builders:
       # requires ssh access to the box running supybot using the jenkins ssh key
       # to download the meeting logs prior to uploading them to repos.fedorapeople
       - shell: |
-          rm -rf *
           # only sync the pulp-dev channel
           # this leaves out meetings in other channels, like the ones in
           # ##pulpbot-firingrange that are all for testing


### PR DESCRIPTION
- include pulpadmin credential where jenkins-ssh-credentials is used
  - jobs that are using jenkins-ssh-credentials expect to have access to
    the fedorapeople site. These jobs are only working because we added
    that key to the jenkins user on the build box, this explicitly adds
    those credentials to the job, allowing it to run anywhere.
- use the clean workspace wrapper instead of 'rm -rf *' in the sync triage
  job
- add timestamps to job build logs by default