### PR TITLE
Run pulp-gen-key-pair and pulp-gen-ca-certificate

### DIFF
--- a/ci/ansible/roles/pulp/tasks/pulp_server.yaml
+++ b/ci/ansible/roles/pulp/tasks/pulp_server.yaml
@@ -78,6 +78,14 @@
 - name: Configure pulp-admin
   shell: "sudo sed -i 's/# verify_ssl: True/verify_ssl: False/g' /etc/pulp/admin/admin.conf"
 
+- name: Generate RSA key pair
+  shell: "sudo pulp-gen-key-pair"
+  when: pulp_version | version_compare('2.13', '>=')
+
+- name: Generate SSL CA certificate
+  shell: "sudo pulp-gen-ca-certificate"
+  when: pulp_version | version_compare('2.13', '>=')
+
 - name: Check if Pulp's DB was initialized
   stat:
     path: /var/lib/pulp/db_initialized.flag


### PR DESCRIPTION
Previously Pulp created the RSA key pair and SSL CA certificate at
installation time, now (Pulp 2.13+) it offers two extra commands that
should be called after installing Pulp packages.

For more information check https://pulp.plan.io/issues/2013