### PR TITLE
Consolidate defaults for privilege escalation

### DIFF
--- a/ci/ansible/ansible.cfg
+++ b/ci/ansible/ansible.cfg
@@ -1,2 +1,6 @@
+# See: docs.ansible.com/ansible/intro_configuration.html
 [defaults]
-remote_user=root
+remote_user = root
+
+[privilege_escalation]
+become = True

--- a/ci/ansible/pulp_coverage.yaml
+++ b/ci/ansible/pulp_coverage.yaml
@@ -2,5 +2,3 @@
 - hosts: all
   roles:
     - role: pulp-coverage
-  become: true
-  become_method: sudo

--- a/ci/ansible/pulp_server.yaml
+++ b/ci/ansible/pulp_server.yaml
@@ -8,5 +8,3 @@
     - role: lazy
       when: pulp_version | version_compare('2.8', '>=')
     - role: pulp-certs
-  become: true
-  become_method: sudo

--- a/ci/ansible/pulp_server_upgrade.yaml
+++ b/ci/ansible/pulp_server_upgrade.yaml
@@ -3,5 +3,3 @@
 - hosts: all
   roles:
     - role: pulp-upgrade
-  become: true
-  become_method: sudo

--- a/ci/ansible/pulp_smash.yaml
+++ b/ci/ansible/pulp_smash.yaml
@@ -3,5 +3,3 @@
 - hosts: all
   roles:
     - pulp-smash
-  become: true
-  become_method: sudo


### PR DESCRIPTION
Identical privilege escalation options are defined in all of the
`pulp_*` playbooks. Move them into `ansible.cfg`.