### PR TITLE
Problem: import of redmine fails on Fedora 25

### DIFF
--- a/ci/redmine_bugzilla.py
+++ b/ci/redmine_bugzilla.py
@@ -43,7 +43,7 @@ import ConfigParser
 import os
 
 from bugzilla.rhbugzilla import RHBugzilla
-from redmine import Redmine
+from redminelib import Redmine
 import urllib3.contrib.pyopenssl
 import xmlrpclib
 


### PR DESCRIPTION
Solution: import from the new python package, redminelib