### PR TITLE
Updates rebase-analysis and some ownership changes

### DIFF
--- a/ci/jobs/macros.yaml
+++ b/ci/jobs/macros.yaml
@@ -64,7 +64,7 @@
             owner: bbouters
             co-owners:
                 - asmacdo
-                - semyers
+                - dkliban
                 - ttereshc
 
 # Ownership that defines owners for Bugzilla/Redmine integration job
@@ -75,16 +75,15 @@
             owner: dadavis
             co-owners:
                 - dkliban
-                - jalberts
 
 # Ownership that indicates developers are the primary contact for the job
 - property:
     name: dev-ownership
     properties:
         - ownership:
-            owner: semyers
+            owner: dkliban
             co-owners:
-                - dkliban
+                - bbouters
 
 # Ownership that indicates quality engineers are the primary contact for the
 # job

--- a/ci/rebase_analysis.py
+++ b/ci/rebase_analysis.py
@@ -109,18 +109,14 @@ def main():
                 upstream_issues_checked_memo[upstream_id] = u''
                 continue
 
-            for custom_field_dict in upstream_issue.custom_fields.resources:
-                if custom_field_dict[u'name'] == u'Platform Release':
+            platform_release_field = upstream_issue.custom_fields.get(4)  # 'Platform Release' field
 
-                    # Never check an upstream issue twice
-                    upstream_issues_checked_memo[upstream_id] = custom_field_dict[u'value']
+            # Never check an upstream issue twice
+            upstream_issues_checked_memo[upstream_id] = platform_release_field[u'value']
 
-                    if custom_field_dict[u'value'] != u'':
-                        upstream_fixed_versions_for_bz.append(custom_field_dict[u'value'])
-                        all_BZs.add(bug.id)
-
-                    # No need to check other custom fields since we've found what we are looking for
-                    break
+            if platform_release_field[u'value'] != u'':
+                upstream_fixed_versions_for_bz.append(platform_release_field[u'value'])
+                all_BZs.add(bug.id)
 
         if upstream_fixed_versions_for_bz != []:
             fix_in = max([semantic_version.Version(v) for v in upstream_fixed_versions_for_bz])


### PR DESCRIPTION
* Updates for changes in python-redmine 2.0.0
* Some job ownership changes due to changing roles

The custom_fields.resources changed and needed to be updated. This
implementation is also more efficient because it fetches the field of
interest directly instead of having to iterate through a list to find
it.

I ran the rebase-analysis job locally and it completed successfully
with these chnages.

The docs-owernship, dev-ownership, and bz-redmine-ownership jobs had
their owners/co-owners changed some based on changing roles.