### PR TITLE
Update automation jobs permutations

### DIFF
--- a/ci/jobs/projects.yaml
+++ b/ci/jobs/projects.yaml
@@ -47,9 +47,9 @@
         - 'f25'
         - 'rhel7'
     pulp_version:
-        - '2.11'
         - '2.12'
-        - '2.13':
+        - '2.13'
+        - '2.14':
             reverse_trigger: 'master'
     exclude:
         - pulp_version: '2.10'


### PR DESCRIPTION
Drop Pulp 2.11, update 2.13 and add 2.14 which is the new master.