### PR TITLE
Add Ansible role to install Pulp Crane

### DIFF
--- a/ci/ansible/pulp_server.yaml
+++ b/ci/ansible/pulp_server.yaml
@@ -8,3 +8,4 @@
     - role: lazy
       when: pulp_version | version_compare('2.8', '>=')
     - role: pulp-certs
+    - role: pulp-crane

--- a/ci/ansible/roles/pulp-crane/files/crane.conf
+++ b/ci/ansible/roles/pulp-crane/files/crane.conf
@@ -1,0 +1,10 @@
+# See:
+#
+# * https://docs.pulpproject.org/plugins/pulp_docker/user-guide/recipes.html
+# * https://docs.pulpproject.org/plugins/crane/index.html
+# * https://pulp.plan.io/issues/2700
+# * https://pulp.plan.io/issues/2717
+#
+[general]
+data_dir: /var/lib/pulp/published/docker
+debug: false

--- a/ci/ansible/roles/pulp-crane/files/pulp_crane.conf
+++ b/ci/ansible/roles/pulp-crane/files/pulp_crane.conf
@@ -1,0 +1,12 @@
+# Place this config in /etc/httpd/conf.d/. Use with Apache 2.4+. See:
+#
+# * https://docs.pulpproject.org/plugins/crane/index.html
+# * https://modwsgi.readthedocs.io/en/develop/user-guides/quick-configuration-guide.html
+#
+Listen 5000
+<VirtualHost *:5000>
+    WSGIScriptAlias / /usr/share/crane/crane.wsgi
+    <Directory /usr/share/crane/>
+        Require all granted
+    </Directory>
+</VirtualHost>

--- a/ci/ansible/roles/pulp-crane/handlers/main.yml
+++ b/ci/ansible/roles/pulp-crane/handlers/main.yml
@@ -1,0 +1,4 @@
+- name: restart apache
+  service:
+    name: httpd
+    state: restarted

--- a/ci/ansible/roles/pulp-crane/tasks/main.yml
+++ b/ci/ansible/roles/pulp-crane/tasks/main.yml
@@ -14,6 +14,14 @@
     mode: 0644
   notify: restart apache
 
+# NOTE: This task exists as a work-around for https://pulp.plan.io/issues/2719
+# When that issue is fixed, this task should be removed.
+- name: "Let Apache bind to port 5000"
+  seboolean:
+    name: httpd_use_openstack
+    state: true
+    persistent: true
+
 - name: Install Crane configuration file
   copy:
     src: crane.conf

--- a/ci/ansible/roles/pulp-crane/tasks/main.yml
+++ b/ci/ansible/roles/pulp-crane/tasks/main.yml
@@ -1,0 +1,30 @@
+- name: Install required packages
+  action: "{{ ansible_pkg_mgr }} name={{ item }} state=present"
+  with_items:
+    - mod_wsgi
+    - python-crane
+  notify: restart apache # for mod_wsgi
+
+- name: Install Apache configuration file
+  copy:
+    src: pulp_crane.conf
+    dest: /etc/httpd/conf.d/pulp_crane.conf
+    owner: root
+    group: root
+    mode: 0644
+  notify: restart apache
+
+- name: Install Crane configuration file
+  copy:
+    src: crane.conf
+    dest: /etc/crane.conf
+    owner: root
+    group: root
+    mode: 0644
+
+- name: Open firewall port for Crane
+  firewalld:
+    port: "5000/tcp"
+    state: enabled
+    permanent: true
+    immediate: true


### PR DESCRIPTION
Make the `pulp_server.yaml` playbook call the new Ansible role,
"pulp-crane."