### PR TITLE
Replace deprecated directive

### DIFF
--- a/ci/ansible/roles/pulp/tasks/main.yaml
+++ b/ci/ansible/roles/pulp/tasks/main.yaml
@@ -155,26 +155,26 @@
   shell: sudo semanage boolean --modify --on pulp_manage_rsync
   when: pulp_version | version_compare('2.10', '>=')
 
-- name: Ensure Apache server is running
+- name: Ensure Apache server is started
   service:
     name: httpd
     enabled: yes
-    state: running
+    state: started
 
-- name: Ensure Pulp workers are running
+- name: Ensure Pulp workers are started
   service:
     name: pulp_workers
     enabled: yes
-    state: running
+    state: started
 
-- name: Ensure Pulp celerybeat is running
+- name: Ensure Pulp celerybeat is started
   service:
     name: pulp_celerybeat
     enabled: yes
-    state: running
+    state: started
 
-- name: Ensure Pulp resource manager is running
+- name: Ensure Pulp resource manager is started
   service:
     name: pulp_resource_manager
     enabled: yes
-    state: running
+    state: started


### PR DESCRIPTION
Ansible's "service" module allows one to declare which state a service
should be in. The allowed states are:

* started
* stopped
* restarted
* reloaded

A state of "running" can also be declared. This state is deprecated and
will be removed in Ansible 2.7. Replace instances of "running" with
"started."