### PR TITLE
Adjust coverage data dir permissions

### DIFF
--- a/ci/ansible/roles/pulp-coverage/tasks/install.yaml
+++ b/ci/ansible/roles/pulp-coverage/tasks/install.yaml
@@ -15,6 +15,12 @@
     mode: 01777
     path: /srv/pulp_coverage
     state: directory
+    group: apache
+    owner: apache
+    selevel: s0
+    serole: object_r
+    seuser: system_u
+    setype: httpd_sys_rw_content_t
 
 - name: Clone coverage repository
   git:


### PR DESCRIPTION
Update group and owner to apache user and set the SELinux context in
order to make Pulp processes write to the coverage data dir.