### PR TITLE
Update pulp-smash-runner job

### DIFF
--- a/ci/jobs/macros.yaml
+++ b/ci/jobs/macros.yaml
@@ -184,6 +184,15 @@
                 - '*/master'
             skip-tag: true
 
+- scm:
+    name: pulp-smash-github
+    scm:
+        - git:
+            url: https://github.com/PulpQE/pulp-smash.git
+            branches:
+                - '*/master'
+            skip-tag: true
+
 - wrapper:
     name: default-ci-workflow-wrappers
     wrappers:

--- a/ci/jobs/pulp-dev.yaml
+++ b/ci/jobs/pulp-dev.yaml
@@ -123,7 +123,7 @@
     properties:
         - qe-ownership
     scm:
-        - pulp-packaging-github
+        - pulp-smash-github
     wrappers:
         - ansicolor
         - timeout:
@@ -155,12 +155,9 @@
             sudo yum -y install python-pip python-virtualenv
             virtualenv -p /usr/bin/python3 venv
             source venv/bin/activate
-            git clone http://github.com/PulpQE/pulp-smash.git
-            cd pulp-smash
             pip install -U setuptools
             pip install -r requirements.txt pytest
 
-            mkdir -p pulp_smash
             cat > pulp_smash/settings.json <<EOF
             {
                 "pulp": {


### PR DESCRIPTION
Pulp packaging repository is not being used anymore so drop it and use
Pulp Smash repository instead. This avoids having to manually clone Pulp
Smash on the build steps.