### PR TITLE
Let templates handle undefined variables

### DIFF
--- a/ci/ansible/roles/pulp-smash/templates/settings.j2
+++ b/ci/ansible/roles/pulp-smash/templates/settings.j2
@@ -2,10 +2,10 @@
     "pulp": {
         "base_url": "{{ pulp_smash_baseurl }}",
         "auth": ["{{ pulp_smash_username }}", "{{ pulp_smash_password }}"],
-        {% if pulp_smash_version %}
+        {% if pulp_smash_version|default() %}
         "version": "{{ pulp_smash_version }}",
         {% endif %}
-        {% if pulp_smash_cli_transport %}
+        {% if pulp_smash_cli_transport|default() %}
         "cli_transport": "{{ pulp_smash_cli_transport }}",
         {% endif %}
         "verify": {{ pulp_smash_verify }}


### PR DESCRIPTION
The pulp-smash role has a template for the Pulp Smash settings file.
This template attempts to deal with undefined variables with the
following Jinja block:

    {% if my_var %}
    use my_var
    {% endif %}

Unfortunately, this doesn't work as intended. If `my_var` doesn't exist,
an exception is raised. Fix this.