### PR TITLE
Make Pulp Smash settings template more robust

### DIFF
--- a/ci/ansible/roles/pulp-smash-virtualenv/templates/settings.j2
+++ b/ci/ansible/roles/pulp-smash-virtualenv/templates/settings.j2
@@ -8,6 +8,12 @@
         {% if pulp_smash_cli_transport|default() %}
         "cli_transport": "{{ pulp_smash_cli_transport }}",
         {% endif %}
-        "verify": {{ pulp_smash_verify }}
+
+        {# "verify" may be either a boolean or a string path to a cert. #}
+        {% if pulp_smash_verify in (true, "true", false, "false") %}
+            "verify": {{ pulp_smash_verify }}
+        {% else %}
+            "verify": "{{ pulp_smash_verify }}"
+        {% endif %}
     }
 }


### PR DESCRIPTION
The "verify" setting in Pulp Smash's `settings.json` file may be either
a boolean or a string path to a certificate. Let the Jinja2 template
which generates this file handle either case.