### PR TITLE
Conditionally install pip into pulp smash venvs

### DIFF
--- a/ci/ansible/roles/pulp-smash-virtualenv/tasks/main.yml
+++ b/ci/ansible/roles/pulp-smash-virtualenv/tasks/main.yml
@@ -18,11 +18,13 @@
     command: python3 -m venv --without-pip "{{ ansible_user_dir }}/.virtualenvs/pulp-smash"
     args:
       creates:  "{{ ansible_user_dir }}/.virtualenvs/pulp-smash"
+    register: result
 
   - name: Ensure pip is present (RHEL)
     shell: >
       source {{ ansible_user_dir }}/.virtualenvs/pulp-smash/bin/activate
       && (which pip || curl https://bootstrap.pypa.io/get-pip.py | python)
+    when: result|changed
 
   when: ansible_distribution == "RedHat"
 


### PR DESCRIPTION
Update the `pulp-smash-virtualenv` role so that the command to install
pip only runs when a new pip-less virtualenv is created. This change
makes the `pulp-smash-virtualenv` role 100% idempotent.