### PR TITLE
Pulp smash new settings

### DIFF
--- a/ci/ansible/roles/pulp-smash-virtualenv/defaults/main.yml
+++ b/ci/ansible/roles/pulp-smash-virtualenv/defaults/main.yml
@@ -1,11 +1,17 @@
-# Pulp Server base URL
-pulp_smash_baseurl: "https://localhost"
+# Pulp system hostname
+pulp_smash_system_hostname: "localhost"
+
+# If Pulp's API is published over HTTPS or HTTP
+pulp_smash_api_scheme: "https"
 
 # Pulp Server username
-pulp_smash_username: "admin"
+pulp_smash_pulp_username: "admin"
 
 # Pulp Server password
-pulp_smash_password: "admin"
+pulp_smash_pulp_password: "admin"
 
 # If SSL certificate should be verified
-pulp_smash_verify: "false"
+pulp_smash_api_verify: "false"
+
+# AMQP broker service either qpidd or rabbitmq
+pulp_smash_amqp_broker_service: "qpidd"

--- a/ci/ansible/roles/pulp-smash-virtualenv/tasks/main.yml
+++ b/ci/ansible/roles/pulp-smash-virtualenv/tasks/main.yml
@@ -61,3 +61,10 @@
   template:
     src: settings.j2
     dest: "{{ ansible_user_dir }}/.config/pulp_smash/settings.json"
+  when: pulp_smash_custom_settings is not defined
+
+- name: Copy custom Pulp Smash configuration file
+  copy:
+    src: "{{ pulp_smash_custom_settings }}"
+    dest: "{{ ansible_user_dir }}/.config/pulp_smash/settings.json"
+  when: pulp_smash_custom_settings is defined

--- a/ci/ansible/roles/pulp-smash-virtualenv/templates/settings.j2
+++ b/ci/ansible/roles/pulp-smash-virtualenv/templates/settings.j2
@@ -1,19 +1,38 @@
 {
     "pulp": {
-        "base_url": "{{ pulp_smash_baseurl }}",
-        "auth": ["{{ pulp_smash_username }}", "{{ pulp_smash_password }}"],
-        {% if pulp_smash_version|default() %}
-        "version": "{{ pulp_smash_version }}",
+        {% if pulp_smash_pulp_version|default() %}
+        "version": "{{ pulp_smash_pulp_version }}",
         {% endif %}
-        {% if pulp_smash_cli_transport|default() %}
-        "cli_transport": "{{ pulp_smash_cli_transport }}",
-        {% endif %}
-
-        {# "verify" may be either a boolean or a string path to a cert. #}
-        {% if pulp_smash_verify in (true, "true", false, "false") %}
-            "verify": {{ pulp_smash_verify }}
-        {% else %}
-            "verify": "{{ pulp_smash_verify }}"
-        {% endif %}
-    }
+        "auth": ["{{ pulp_smash_pulp_username }}", "{{ pulp_smash_pulp_password }}"]
+    },
+    "systems": [
+        {
+            "hostname": "{{ pulp_smash_system_hostname }}",
+            "roles": {
+                "amqp broker": {
+                    "service": "{{ pulp_smash_amqp_broker_service }}"
+                },
+                "api": {
+                    "scheme": "{{ pulp_smash_api_scheme }}",
+                    {# "verify" may be either a boolean or a string path to a cert. #}
+                    {% if pulp_smash_api_verify in (true, "true", false, "false") %}
+                    "verify": {{ pulp_smash_api_verify }}
+                    {% else %}
+                    "verify": "{{ pulp_smash_api_verify }}"
+                    {% endif %}
+                },
+                "mongod": {},
+                "pulp celerybeat": {},
+                "pulp cli": {},
+                "pulp resource manager": {},
+                "pulp workers": {},
+                "shell": {
+                    {% if pulp_smash_shell_transport|default() %}
+                    "transport": "{{ pulp_smash_shell_transport }}"
+                    {% endif %}
+                },
+                "squid": {}
+            }
+        }
+    ]
 }

--- a/ci/jobs/pulp-dev.yaml
+++ b/ci/jobs/pulp-dev.yaml
@@ -35,8 +35,8 @@
                 - pulp-smash-runner
               block: true
               predefined-parameters: |
-                  BASE_URL=$BASE_URL
-                  PULP_VERSION=$PULP_VERSION
+                  PULP_SMASH_SYSTEM_HOSTNAME=$PULP_SMASH_SYSTEM_HOSTNAME
+                  PULP_SMASH_PULP_VERSION=$PULP_SMASH_PULP_VERSION
               block-thresholds:
                   build-step-failure-threshold: never
                   unstable-threshold: never
@@ -98,75 +98,5 @@
         - archive:
             artifacts: "*.tar.gz"
             allow-empty: true
-        - email-notify-owners
-        - mark-node-offline
-
-- job:
-    name: pulp-smash-runner
-    concurrent: true
-    properties:
-        - copyartifact:
-            projects: pulp-*-dev-*
-    node: pulp-smash-np
-    parameters:
-        - string:
-            name: BASE_URL
-        - string:
-            name: PULP_VERSION
-            decription: Pulp version setup on the server.
-        - file:
-            name: PRIVATE_KEY
-            description: Private ssh key to connect on the server.
-        - file:
-            name: CA_CERT
-            description: The CA certificate that signed the Pulp apache server.
-    properties:
-        - qe-ownership
-    scm:
-        - pulp-packaging-github
-    wrappers:
-        - ansicolor
-        - timeout:
-            # pulp-smash usually takes about an hour or two, so time it out
-            # after 7:40 hours. This gives room to some tasks time out.
-            timeout: 460
-            abort: true
-        - timestamps
-    builders:
-        - shell: |
-            # Setup ssh config and private key
-            mkdir ~/.ssh/controlmasters
-            cat > ~/.ssh/config <<EOF
-            Host $(echo ${BASE_URL} | cut -d/ -f3)
-                User jenkins
-                StrictHostKeyChecking no
-                UserKnownHostsFile /dev/null
-                IdentityFile ${PWD}/PRIVATE_KEY
-                ControlMaster auto
-                ControlPersist 5m
-                ControlPath ~/.ssh/controlmasters/%C
-            EOF
-            chmod 600 PRIVATE_KEY ~/.ssh/config
-
-            # Set up the CA certificate that signed Pulp's apache server.
-            sudo cp CA_CERT /etc/pki/ca-trust/source/anchors/cacert.pem
-            sudo update-ca-trust
-
-            sudo dnf -y install ansible attr git libselinux-python
-            echo 'localhost' > hosts
-            export ANSIBLE_CONFIG="${PWD}/ci/ansible/ansible.cfg"
-            ansible-playbook --connection local -i hosts ci/ansible/pulp_smash.yaml \
-                -e pulp_smash_baseurl="${BASE_URL}" \
-                -e pulp_smash_cli_transport="ssh" \
-                -e pulp_smash_verify="/etc/pki/ca-trust/source/anchors/cacert.pem" \
-                -e pulp_smash_version="${PULP_VERSION}"
-            source ~/.virtualenvs/pulp-smash/bin/activate
-            set +e
-            py.test -v --color=yes --junit-xml=junit-report.xml --pyargs pulp_smash.tests
-            set -e
-            test -f junit-report.xml
-    publishers:
-        - archive:
-            artifacts: 'junit-report.xml'
         - email-notify-owners
         - mark-node-offline

--- a/ci/jobs/pulp-smash-runner.yaml
+++ b/ci/jobs/pulp-smash-runner.yaml
@@ -1,0 +1,125 @@
+- job:
+    name: pulp-smash-runner
+    concurrent: true
+    properties:
+        - copyartifact:
+            projects: pulp-*-dev-*
+    node: pulp-smash-np
+    parameters:
+        - string:
+            name: PULP_SMASH_SYSTEM_HOSTNAME
+        - string:
+            name: PULP_SMASH_PULP_VERSION
+            decription: The Pulp version Pulp Smash will consider when running tests.
+        - string:
+            name: PULP_SMASH_PULP_USERNAME
+            default: admin
+        - string:
+            name: PULP_SMASH_PULP_PASSWORD
+            default: admin
+        - choice:
+            name: PULP_SMASH_AMQP_BROKER_SERVICE
+            choices:
+                - qpidd
+                - rabbitmq
+        - choice:
+            name: PULP_SMASH_API_SCHEME
+            choices:
+                - https
+                - http
+        - bool:
+            name: PULP_SMASH_API_VERIFY
+            default: true
+        - file:
+            name: SSH_PRIVATE_KEY
+            description: Private ssh key to connect on the server.
+        - file:
+            name: SSH_CUSTOM_CONFIG
+            description: >
+                If a custom SSH config is provided then it will be used instead
+                of creating one. The variable {SSH_PRIVATE_KEY} will be
+                replaced with the path of the SSH_PRIVATE_KEY file.
+        - file:
+            name: PULP_CA_CERT
+            description: >
+                The CA certificate that signed the Pulp apache server. If this
+                is provided and PULP_SMASH_API_VERIFY is true then Pulp Smash
+                will use the certificate to verify the HTTP[S] connection
+        - file:
+            name: PULP_SMASH_CUSTOM_SETTINGS
+            description: >
+                If a custom Pulp Smash settings file content is passed on this
+                parameter then all other parameters will be ignored but
+                SSH_PRIVATE_KEY and PULP_CA_CERT which will set up SSH
+                connection and update the certificate trust respectively. The
+                variable {PULP_CA_CERT_PATH} will be replaced with the path
+                where the CA certificate was installed.
+    properties:
+        - qe-ownership
+    scm:
+        - pulp-packaging-github
+    wrappers:
+        - ansicolor
+        - timeout:
+            # pulp-smash usually takes about an hour or two, so time it out
+            # after 7:40 hours. This gives room to some tasks time out.
+            timeout: 460
+            abort: true
+        - timestamps
+    builders:
+        - shell: |
+            # Setup ssh config and private key
+            mkdir ~/.ssh/controlmasters
+            if [ -f SSH_CUSTOM_CONFIG ]; then
+                sed -i -e "s|{SSH_PRIVATE_KEY_PATH}|${PWD}/PRIVATE_KEY|" SSH_CUSTOM_CONFIG
+                cp SSH_CUSTOM_CONFIG ~/.ssh/config
+            else
+                cat > ~/.ssh/config <<EOF
+            Host ${PULP_SMASH_SYSTEM_HOSTNAME}
+                User jenkins
+                StrictHostKeyChecking no
+                UserKnownHostsFile /dev/null
+                IdentityFile ${PWD}/PRIVATE_KEY
+                ControlMaster auto
+                ControlPersist 5m
+                ControlPath ~/.ssh/controlmasters/%C
+            EOF
+            fi
+            chmod 600 PRIVATE_KEY ~/.ssh/config
+
+            # Set up the CA certificate that signed Pulp's apache server.
+            export PULP_CA_CERT_PATH="/etc/pki/ca-trust/source/anchors/pulp-cacert.pem"
+            sudo cp CA_CERT "${PULP_CA_CERT_PATH}"
+            sudo update-ca-trust
+
+            sudo dnf -y install ansible attr git libselinux-python
+            export ANSIBLE_CONFIG="${PWD}/ci/ansible/ansible.cfg"
+            if [ "${PULP_SMASH_API_VERIFY}" = "true" ]; then
+                export PULP_SMASH_API_VERIFY="${PULP_CA_CERT_PATH}"
+            fi
+            if [ -f PULP_SMASH_CUSTOM_SETTINGS ]; then
+                sed -i -e "s|{PULP_CA_CERT_PATH}|${PULP_CA_CERT_PATH}|" \
+                    PULP_SMASH_CUSTOM_SETTINGS
+                ansible-playbook --connection local -i "localhost," ci/ansible/pulp_smash.yaml \
+                    -e pulp_smash_custom_settings PULP_SMASH_CUSTOM_SETTINGS
+            else
+                ansible-playbook --connection local -i "localhost," ci/ansible/pulp_smash.yaml \
+                    -e pulp_smash_system_hostname="${PULP_SMASH_SYSTEM_HOSTNAME}" \
+                    -e pulp_smash_shell_transport="ssh" \
+                    -e pulp_smash_amqp_broker_service="${PULP_SMASH_AMQP_BROKER_SERVICE}" \
+                    -e pulp_smash_api_scheme="${PULP_SMASH_API_SCHEME}" \
+                    -e pulp_smash_api_verify="${PULP_SMASH_API_VERIFY}" \
+                    -e pulp_smash_pulp_username="${PULP_SMASH_PULP_USERNAME}" \
+                    -e pulp_smash_pulp_password="${PULP_SMASH_PULP_PASSWORD}" \
+                    -e pulp_smash_pulp_version="${PULP_SMASH_PULP_VERSION}"
+            fi
+            source ~/.virtualenvs/pulp-smash/bin/activate
+            set +e
+            py.test -v --color=yes --junit-xml=junit-report.xml --pyargs pulp_smash.tests
+            set -e
+            test -f junit-report.xml
+    publishers:
+        - archive:
+            artifacts: 'junit-report.xml'
+        - email-notify-owners
+        - mark-node-offline

--- a/ci/jobs/pulp-upgrade.yaml
+++ b/ci/jobs/pulp-upgrade.yaml
@@ -62,8 +62,8 @@
                 - pulp-smash-runner
               block: true
               predefined-parameters: |
-                  BASE_URL=$BASE_URL
-                  PULP_VERSION=$UPGRADE_PULP_VERSION
+                  PULP_SMASH_SYSTEM_HOSTNAME=$PULP_SMASH_SYSTEM_HOSTNAME
+                  PULP_SMASH_PULP_VERSION=$PULP_SMASH_PULP_VERSION
               block-thresholds:
                   build-step-failure-threshold: never
                   unstable-threshold: never

--- a/ci/jobs/scripts/pulp-smash-parameters.sh
+++ b/ci/jobs/scripts/pulp-smash-parameters.sh
@@ -1,8 +1,8 @@
-echo "BASE_URL=https://$(hostname --long)" > parameters.txt
+echo "PULP_SMASH_SYSTEM_HOSTNAME=$(hostname --long)" > parameters.txt
 PULP_RPM_VERSION="$(rpm -qa pulp-server | cut -d- -f3)"
 if [ "${PULP_VERSION}" != "$(cut -d. -f-2 <<< "${PULP_RPM_VERSION}")" ]; then
     echo "Pulp RPM version ${PULP_RPM_VERSION} is not in the ${PULP_VERSION} series"
     exit 1
 fi
-echo "PULP_VERSION=${PULP_RPM_VERSION}" >> parameters.txt
+echo "PULP_SMASH_PULP_VERSION=${PULP_RPM_VERSION}" >> parameters.txt
 cp /etc/pki/CA/cacert.pem cacert.pem


### PR DESCRIPTION
Added two commits to:

1. Update Pulp Smash ansible role to use the new Pulp Smash settings file format. Had to rename variables to be more meaningful.
2. Update all the Pulp automation jobs to properly trigger the updated pulp-smash-runner job which is now accepting the parameters to deal with the new Pulp Smash settings file format.