### PR TITLE
Problem: plugin PR builder uses older core RPMs

### DIFF
--- a/ci/jobs/unittests.yaml
+++ b/ci/jobs/unittests.yaml
@@ -232,25 +232,10 @@
             OS_NAME=$(lsb_release -si)
             OS_VERSION=$(lsb_release -sr | cut -f1 -d.)
 
-            # Get the required pulp server
-            pushd plugin
-            if [ "$OS_NAME" == "RedHatEnterpriseServer" ] && [ "$OS_VERSION"  \< "7" ]; then
-              # unfortunately rpmspec doesn't work on rhel 5 & 6 so we have to use the older rpmquery
-              server_requires=$(rpmquery --requires --specfile *.spec | grep pulp-server)
-              requires_minus_spaces=$(echo $server_requires | sed 's/[[:space:]]//g')
-              PULP_VERSION=$(echo $requires_minus_spaces | sed -r 's/pulp-server(>=|==|=)([0-9]+\.[0-9]+).*/\2/')
-            else
-              server_requires=$(rpmspec -P *.spec | grep pulp-server)
-              requires_minus_spaces=$(echo $server_requires | sed 's/[[:space:]]//g')
-              PULP_VERSION=$(echo $requires_minus_spaces | sed -r 's/Requires:pulp-server(>=|==|=)([0-9]+\.[0-9]+).*/\2/')
-            fi
-
-            popd
-            echo $PULP_VERSION
             if [ "$OS_NAME" == "RedHatEnterpriseServer" ]; then
-                REPO_URL="https://repos.fedorapeople.org/repos/pulp/pulp/testing/automation/$PULP_VERSION/stage/\$releasever/\$basearch/"
+                REPO_URL="https://repos.fedorapeople.org/repos/pulp/pulp/stable/latest/\$releasever/\$basearch/"
             else
-                REPO_URL="https://repos.fedorapeople.org/repos/pulp/pulp/testing/automation/$PULP_VERSION/stage/fedora-\$releasever/\$basearch/"
+                REPO_URL="https://repos.fedorapeople.org/repos/pulp/pulp/stable/latest/fedora-\$releasever/\$basearch/"
             fi
 
             cat > pulp-deps.repo<< EndOfMessage


### PR DESCRIPTION
Solution: always install core from the latest nightly build of master branch

closes #2751
https://pulp.plan.io/issues/2751