### PR TITLE
Update satellite6-upgrade-pulp jobs

### DIFF
--- a/ci/jobs/projects.yaml
+++ b/ci/jobs/projects.yaml
@@ -130,18 +130,11 @@
         - '{stream}-satellite6-upgrade-pulp'
     instance_name: '{stream}-satellite6-upgrade-pulp'
     robottelo_branch: 'master'
+    pulp_upgrade_repo_url: 'https://repos.fedorapeople.org/pulp/pulp/stable/2.13/7Server/x86_64/'
     stream:
         - downstream:
             satellite_distribution: 'INTERNAL'
-            satellite_version: '6.2'
-            robottelo_branch: '6.2.z'
-            pulp_upgrade_repo_url:
-                'https://repos.fedorapeople.org/pulp/pulp/beta/2.8/7Server/x86_64/'
-        - upstream:
-            satellite_distribution: 'UPSTREAM'
-            satellite_version: 'nightly'
-            pulp_upgrade_repo_url:
-                'https://repos.fedorapeople.org/pulp/pulp/stable/2.10/7Server/x86_64/'
+            satellite_version: '6.3'
 
 - project:
     name: sync

--- a/ci/jobs/scripts/openstack-upgrade-pulp.sh
+++ b/ci/jobs/scripts/openstack-upgrade-pulp.sh
@@ -4,11 +4,23 @@ ssh exit 0
 ssh sudo katello-service stop
 ssh rpm -qa | grep pulp
 ssh rpm -q satellite
+ssh sudo yum -y install yum-utils
 ssh sudo yum-config-manager --add-repo "${PULP_UPGRADE_REPO_URL}"
 ssh sudo yum repolist enabled | grep pulp
-ssh sudo yum update -y --nogpgcheck "pulp-*"
+# We can't add EPEL repository, that avoids package conflict. We still need to
+# install python-billiard from EPEL though
+ssh sudo yum -y install http://dl.fedoraproject.org/pub/epel/7/x86_64/p/python-billiard-3.3.0.20-2.el7.x86_64.rpm
+
+ssh sudo yum update -y --nogpgcheck
 ssh rpm -qa | grep pulp
-ssh sudo katello-service restart
+ssh rpm -qa | grep python
+
+# We need mongod started to run pulp-manage-db. Don't call katello-service
+# restart because pulp-manage-db won't do anything if some of pulp processes
+# are running.
+ssh sudo systemctl start mongod
 ssh sudo -u apache pulp-manage-db
+ssh sudo katello-service start
+
 UPDATE_PULP_VERSION="$(ssh rpm -qa | grep pulp-server | awk -F'-' '{ print $3 }')"
 echo "Pulp upgraded to ${UPDATE_PULP_VERSION} version."

--- a/ci/jobs/scripts/remote_jenkins_trigger.py
+++ b/ci/jobs/scripts/remote_jenkins_trigger.py
@@ -16,20 +16,12 @@ JENKINS_USERNAME = os.environ.get('REMOTE_JENKINS_USERNAME')
 JOB_NAME = '{job_name}'
 
 logging.captureWarnings(True)
-print('Get crumb from Satellite Jenkins server...')
-crumb = requests.get(
-    JENKINS_URL + '/crumbIssuer/api/json',
-    auth=(JENKINS_USERNAME, JENKINS_API_TOKEN),
-    verify=False
-).json()
-
 print('Queuing job {{}}...'.format(JOB_NAME))
 queue_url = requests.post(
     JENKINS_URL + '/job/{{}}/buildWithParameters'
     .format(JOB_NAME),
     auth=(JENKINS_USERNAME, JENKINS_API_TOKEN),
     data={{
-        crumb['crumbRequestField']: crumb['crumb'],
         {job_parameters}
     }},
     verify=False


### PR DESCRIPTION
Do the following:

* Upgrade Pulp to 2.13 on downstream Satellite
* Drop upstream Satellite job since it is already packet with 2.13
* Use openstack client since nova client has deprecated some of its
subcommands in favor of the openstack client.
* Install yum-utils before running yum-config-manager