### PR TITLE
fix pulp install on machines with apache 2.2 and iptables

### DIFF
--- a/ci/ansible/roles/pulp-crane/files/crane_el6.wsgi
+++ b/ci/ansible/roles/pulp-crane/files/crane_el6.wsgi
@@ -1,0 +1,7 @@
+# see:
+# https://raw.githubusercontent.com/pulp/crane/3c657fe53020b804ce60d907a82b4fb19aebe532/deployment/crane_el6.wsgi
+# for this unpleasantry is necessary.
+import sys
+sys.path.insert(0, '/usr/lib/python2.6/site-packages/Jinja2-2.6-py2.6.egg')
+
+from crane.wsgi import application

--- a/ci/ansible/roles/pulp-crane/files/pulp_crane_el6.conf
+++ b/ci/ansible/roles/pulp-crane/files/pulp_crane_el6.conf
@@ -1,0 +1,15 @@
+# source:
+# https://raw.githubusercontent.com/pulp/crane/3c657fe53020b804ce60d907a82b4fb19aebe532/deployment/apache22.conf
+# Use this config with Apache 2.2 or earlier
+Listen 5000
+<VirtualHost *:5000>
+    WSGIScriptAlias / /usr/share/crane/crane_el6.wsgi
+    <Location /crane>
+        Order deny,allow
+        Allow from all
+    </Location>
+    <Directory /usr/share/crane/>
+        Order allow,deny
+        Allow from all
+    </Directory>
+</VirtualHost>

--- a/ci/ansible/roles/pulp-crane/handlers/main.yml
+++ b/ci/ansible/roles/pulp-crane/handlers/main.yml
@@ -2,3 +2,6 @@
   service:
     name: httpd
     state: restarted
+
+- name: Save IPv4 iptables configuration
+  shell: 'iptables-save > /etc/sysconfig/iptables'

--- a/ci/ansible/roles/pulp-crane/tasks/main.yml
+++ b/ci/ansible/roles/pulp-crane/tasks/main.yml
@@ -30,9 +30,25 @@
     group: root
     mode: 0644
 
-- name: Open firewall port for Crane
+- name: Open firewall port for Crane (iptables)
+  iptables:
+    action: insert
+    chain: INPUT
+    ctstate: NEW
+    protocol: tcp
+    destination_port: 5000
+    jump: ACCEPT
+  when:
+    - ansible_distribution == "RedHat"
+    - ansible_distribution_major_version|int == 6
+  notify:
+    - Save IPv4 iptables configuration
+
+- name: Open firewall port for Crane (firewalld)
   firewalld:
     port: "5000/tcp"
     state: enabled
     permanent: true
     immediate: true
+  when:
+    - not (ansible_distribution == "RedHat" and ansible_distribution_major_version|int == 6)

--- a/ci/ansible/roles/pulp-crane/tasks/main.yml
+++ b/ci/ansible/roles/pulp-crane/tasks/main.yml
@@ -13,6 +13,19 @@
     group: root
     mode: 0644
   notify: restart apache
+  when:
+    - not (ansible_distribution == "RedHat" and ansible_distribution_major_version|int == 6)
+
+- name: Install Apache configuration file for Apache version 2.2 or less
+  copy:
+    src: pulp_crane_el6.conf
+    dest: /etc/httpd/conf.d/pulp_crane_el6.conf
+    owner: root
+    group: root
+    mode: 0644
+  notify: restart apache
+  when:
+    - (ansible_distribution == "RedHat" and ansible_distribution_major_version|int == 6)
 
 # NOTE: This task exists as a work-around for https://pulp.plan.io/issues/2719
 # When that issue is fixed, this task should be removed.
@@ -30,20 +43,6 @@
     group: root
     mode: 0644
 
-- name: Open firewall port for Crane (iptables)
-  iptables:
-    action: insert
-    chain: INPUT
-    ctstate: NEW
-    protocol: tcp
-    destination_port: 5000
-    jump: ACCEPT
-  when:
-    - ansible_distribution == "RedHat"
-    - ansible_distribution_major_version|int == 6
-  notify:
-    - Save IPv4 iptables configuration
-
 - name: Open firewall port for Crane (firewalld)
   firewalld:
     port: "5000/tcp"
@@ -51,4 +50,26 @@
     permanent: true
     immediate: true
   when:
-    - not (ansible_distribution == "RedHat" and ansible_distribution_major_version|int == 6)
+  - not (ansible_distribution == "RedHat" and ansible_distribution_major_version|int == 6)
+
+- block:
+  - name: Install Crane WSGI config file (RHEL 6)
+    copy:
+      src: crane_el6.wsgi
+      dest: /usr/share/crane/crane_el6.wsgi
+      owner: root
+      group: root
+      mode: 0644
+
+  - name: Open firewall port for Crane (iptables)
+    iptables:
+      action: insert
+      chain: INPUT
+      ctstate: NEW
+      protocol: tcp
+      destination_port: 5000
+      jump: ACCEPT
+    notify:
+      - Save IPv4 iptables configuration
+  when:
+    - (ansible_distribution == "RedHat" and ansible_distribution_major_version|int == 6)

--- a/ci/ansible/roles/pulp/tasks/main.yaml
+++ b/ci/ansible/roles/pulp/tasks/main.yaml
@@ -1,23 +1,38 @@
 ---
+- block:
+  - name: Open firewall ports (iptables)
+    iptables:
+      action: insert
+      chain: INPUT
+      ctstate: NEW
+      protocol: "{{ item.protocol }}"
+      destination_port: "{{ item.port }}"
+      jump: ACCEPT
+    with_items:
+      - { port: 'http', protocol: 'tcp' }
+      - { port: 'https', protocol: 'tcp' }
+      - { port: 'amqps', protocol: 'tcp' }
+      - { port: 'amqp', protocol: 'tcp' }
+    notify:
+      - Save IPv4 iptables configuration
 
-- name: Open firewall ports (iptables)
-  iptables:
-    action: insert
-    chain: INPUT
-    ctstate: NEW
-    protocol: "{{ item.protocol }}"
-    destination_port: "{{ item.port }}"
-    jump: ACCEPT
-  with_items:
-    - { port: 'http', protocol: 'tcp' }
-    - { port: 'https', protocol: 'tcp' }
-    - { port: 'amqps', protocol: 'tcp' }
-    - { port: 'amqp', protocol: 'tcp' }
+  - name: Install required packages for RHEL 6
+    action: "{{ ansible_pkg_mgr }} name={{ item }} state=latest"
+    with_items:
+        - libselinux-python
+        - policycoreutils-python
+
+  - name: Setup qpid custom repo
+    get_url: url=https://copr.fedorainfracloud.org/coprs/g/qpid/qpid/repo/epel-6/irina-qpid-epel-6.repo dest=/etc/yum.repos.d/copr-qpid.repo
+
+  - name:  Allow Apache to listen on tcp port 5000
+    seport:
+      ports: 5000
+      proto: tcp
+      setype: http_port_t
+      state: present
   when:
-    - ansible_distribution == "RedHat"
-    - ansible_distribution_major_version|int == 6
-  notify:
-    - Save IPv4 iptables configuration
+      - (ansible_distribution == "RedHat" and ansible_distribution_major_version|int == 6)
 
 - block:
   - name: Install firewalld and python bindings
@@ -56,12 +71,6 @@
 
 - name: Start and enable MongoDB server service
   service: name=mongod state=started enabled=yes
-
-- name: Setup qpid custom repo
-  get_url: url=https://copr.fedorainfracloud.org/coprs/g/qpid/qpid/repo/epel-6/irina-qpid-epel-6.repo dest=/etc/yum.repos.d/copr-qpid.repo
-  when:
-    - ansible_os_family == "RedHat"
-    - ansible_distribution_major_version|int == 6
 
 - name: Install qpid-cpp server
   action: "{{ ansible_pkg_mgr }} name={{ item }} state=latest"


### PR DESCRIPTION
I have tested running the pulp_server.yaml playbook to install pulp on a clean RHEL6.9 server and RHEL7.3 server (my F25 laptop as control node)

I did move around some existing tasks into blocks since more tasks that all were conditional on `(ansible_distribution == "RedHat" and ansible_distribution_major_version|int == 6)` were added.

@elyezer what more should I do to get this ready to merge?

Thanks @Ichimonji10 for giving me a head start on this fix