### PR TITLE
Replace deprecated job property: logrotate

### DIFF
--- a/ci/jobs/defaults.yaml
+++ b/ci/jobs/defaults.yaml
@@ -12,9 +12,9 @@
     description: |
         Managed by Jenkins Job Builder. Do not edit via web.
     concurrent: false
-    logrotate:
-        daysToKeep: 10
-        numToKeep: 30
+    build-discarder:
+        days-to-keep: 10
+        num-to-keep: 30
     wrappers:
         - default-ci-workflow-wrappers
         - timestamps


### PR DESCRIPTION
The `logrotate` job property is deprecated as of Jenkins 1.637. Use the
`build-discarder` job property instead. See:

* https://docs.openstack.org/infra/jenkins-job-builder/definition.html#job
* https://docs.openstack.org/infra/jenkins-job-builder/properties.html#properties.build-discarder