### PR TITLE
Add job to test pulp 2.14 on fedora 26

### DIFF
--- a/ci/jobs/projects.yaml
+++ b/ci/jobs/projects.yaml
@@ -45,6 +45,7 @@
     os:
         - 'f24'
         - 'f25'
+        - 'f26'
         - 'rhel7'
     pulp_version:
         - '2.12'
@@ -53,8 +54,10 @@
         - '2.15':
             reverse_trigger: 'master'
     exclude:
-        - pulp_version: '2.10'
-          os: 'f25'
+        - pulp_version: '2.12'
+          os: 'f26'
+        - pulp_version: '2.13'
+          os: 'f26'
     reverse_trigger: '{pulp_version}-dev'
     jobs:
         - pulp-{pulp_version}-dev-{os}


### PR DESCRIPTION
Now we are able to provision fedora 26 nodes and these changes enable generation of job to test 2.14 on fedora 26.