### PR TITLE
Don't build docs for pulp_deb

### DIFF
--- a/ci/docs-builder.py
+++ b/ci/docs-builder.py
@@ -73,6 +73,9 @@ def main():
             promote.update_versions(os.path.join(WORKING_DIR, 'pulp'), *version.split('-'))
             continue
 
+        if component['name'] == 'pulp_deb':
+            continue
+
         src = os.sep.join([WORKING_DIR, component['name'], 'docs'])
         dst = os.sep.join([plugins_dir, component['name']])
         os.symlink(src, dst)


### PR DESCRIPTION
Problem: Adding pulp_deb to the releases config causes the docs builder
to fail due to pulp_deb rst files not being included in any toctree.

Solution: Don't build pulp_deb docs for Pulp2 and have them continue to
self-host as they have been.