### PR TITLE
Moves around the owner of two jobs

### DIFF
--- a/ci/jjb/jobs/macros.yaml
+++ b/ci/jjb/jobs/macros.yaml
@@ -68,9 +68,9 @@
                 - dkliban
                 - ttereshc
 
-# Ownership that defines owners for Bugzilla/Redmine integration job
+# Ownership that defines owners for Satellite related job
 - property:
-    name: bz-redmine-ownership
+    name: satellite-ownership
     properties:
         - ownership:
             owner: dadavis

--- a/ci/jjb/jobs/pr-docs.yaml
+++ b/ci/jjb/jobs/pr-docs.yaml
@@ -18,7 +18,7 @@
         - matrix-combinations:
             name: MATRIX_AXIS
     properties:
-      - dev-ownership
+      - docs-ownership
       - github:
           url: https://github.com/pulp/pulp/
     scm:

--- a/ci/jjb/jobs/rebase_analysis.yaml
+++ b/ci/jjb/jobs/rebase_analysis.yaml
@@ -6,7 +6,7 @@
     defaults: ci-workflow-runtest
     node: 'f25-np'
     properties:
-        - dev-ownership
+        - satellite-ownership
     scm:
         - git:
             url: 'https://github.com/pulp/pulp_packaging.git'

--- a/ci/jjb/jobs/redmine.yaml
+++ b/ci/jjb/jobs/redmine.yaml
@@ -6,7 +6,7 @@
     defaults: ci-workflow-runtest
     node: 'f25-np'
     properties:
-        - bz-redmine-ownership
+        - satellite-ownership
     scm:
         - git:
             url: 'https://github.com/pulp/pulp_packaging.git'


### PR DESCRIPTION
* Rename the bz-automation-ownership group to be the
  satellite-ownership group. Also update existing jobs to use the new
  name.
* Move the pr-docs builder to be owned by the docs-ownership group
* Move the rebase_analysis job to be owned by the satellite-ownership
  group.