### PR TITLE
Removing rhel6 from 2.14 upgrade

### DIFF
--- a/ci/jjb/jobs/projects.yaml
+++ b/ci/jjb/jobs/projects.yaml
@@ -138,6 +138,8 @@
           upgrade_pulp_version: 2.12-beta
         - os: rhel6
           upgrade_pulp_version: 2.13-beta
+        - os: rhel6
+          upgrade_pulp_version: 2.14-beta
     jobs:
         - 'pulp-upgrade-{pulp_version}-{upgrade_pulp_version}-{os}'
 


### PR DESCRIPTION
Forgot to remove rhel6 from 2.14 permutations.