### PR TITLE
Add roles to populate, backup, and restore pulp

### DIFF
--- a/ci/ansible/pulp_backup.yaml
+++ b/ci/ansible/pulp_backup.yaml
@@ -1,0 +1,61 @@
+---
+
+- hosts: all
+  vars:
+    skip_populate: false
+  roles:
+    - role: subscription-manager
+      when: ansible_distribution == 'RedHat'
+    - role: pulp
+    - role: lazy
+      when: pulp_version | version_compare('2.8', '>=')
+    - role: pulp-certs
+    - role: pulp-crane
+    - role: pulp-populate
+      when: not skip_populate
+    - role: pulp-test-populate
+    - role: pulp-backup
+
+# This playbook runs roles to install pulp on a host, then populate it with
+# content and back up that content. It is possible to skip population by
+# setting "skip_populate" to "true"
+#
+# Be advised that this play will attempt to create a directory on the control
+# node to fetch the backed up files. This behavior can be controlled by setting
+# variables on invocation. See details below.
+#
+# Example invocation:
+#
+# ansible-playbook -i ~/hosts -l rhel6 pulp_backup.yaml \
+#                   -e local_bkup_dir=${HOME}/backups \
+#                   -e remote_bkup_dir=/root/backups \
+#                   -e rhn_password=my_pass \
+#                   -e 'rhn_pool=my_pool' \
+#                   -e rhn_username=my_username \
+#                   -e pulp_build='stable' \
+#                   -e pulp_version=2.11
+#
+# This would install 2.11 on the rhel6 host in your hosts file, and
+# fetch the backups to a directory named "backups" in your home directory.
+#
+# Variables you might want to specify on invocation:
+#
+# fetch_to_localhost: [boolean] default: TRUE
+#   When true, a directory is created on the control node in which
+#   to fetch the backups. If you have troubles with this, you may
+#   elect to create the directory in advance and pass:
+#   "-e local_bkup_dir='path/to/your/dir'"
+#
+# local_bkup_dir: [absolute path on control node] default "local_backups"
+#   This will create a directory, by default "local_backups" in the
+#   directory where the playbook was invoked.
+#
+# remote_bkup_dir: [absolute path on pulp host] default:
+#           "{{ ansible_user_dir }}/remote_backups"
+#   This will create a directory on the remote host in which to place the
+#   archives before they are fetched. When the files are fetched to the
+#   control node, this directory is destroyed.
+#
+# skip_populate: [boolean] default: FALSE
+#   Set this to TRUE if you want to not populate the server with fixture
+#   data.

--- a/ci/ansible/pulp_restore.yaml
+++ b/ci/ansible/pulp_restore.yaml
@@ -1,0 +1,72 @@
+---
+
+- hosts: all
+  vars:
+    skip_restore_test: false
+  roles:
+    - role: subscription-manager
+      when: ansible_distribution == 'RedHat'
+    - role: pulp
+    - role: lazy
+      when: pulp_version | version_compare('2.8', '>=')
+    - role: pulp-certs
+    - role: pulp-crane
+    - role: pulp-restore-backup
+    - role: pulp-test-populate
+      when: not skip_restore_test
+
+# This playbook runs roles to install pulp on a host, then restore previously
+# backed up data.
+#
+# It expects that the data is in the from that the pulp_backup.yaml
+# playbook delivers. See `local_bkup_dir` below.
+#
+# Example invocation:
+#
+# ansible-playbook -i ~/hosts -l rhel7 pulp_restore.yaml \
+#                   -e local_bkup_dir=${HOME}/backups \
+#                   -e remote_bkup_dir=/root/backups \
+#                   -e rhn_password=my_pass \
+#                   -e 'rhn_pool=my_pool' \
+#                   -e rhn_username=my_username \
+#                   -e pulp_build='stable' \
+#                   -e pulp_version=2.13' \
+#                   -e test_results_dir='/root'
+#
+# This would install 2.13 on the rhel7 host in your hosts file, and
+# restore the backups found in ${HOME}/backups to the rhel7 host.
+# Then it would run tests to report on the status of the restore
+# and produce an xml report found in /root on the pulp host.
+#
+# Variables you might want to specify on invocation:
+#
+# local_bkup_dir: [absolute path on control node] default "local_backups"
+#    This should point to a directory that, by default, has the following
+#    contents, as is produced by the pulp-backup role.
+#
+#    local_bkup_dir/
+#               ├── etc_pki_pulp.tar.bz2 # archive of /etc/pki/pulp/
+#               ├── etc_pulp.tar.bz2     # archive of /etc/pulp/
+#               ├── mongodb_backup.bz2   # archive of mongodump of pulp_database
+#               └── var_lib_pulp.tar.bz2 # archive of /var/lib/pulp
+#
+#    If you would like to
+#    provide your own archives, you can edit the files_to_restore dictionary
+#    in "roles/pulp-restore-backup/defaults/main.yaml"
+#
+# remote_bkup_dir: [absolute path on pulp host] default:
+#           "{{ ansible_user_dir }}/remote_backups"
+#   This will create a directory on the remote host or use an existing
+#   directory if one is provided in which to place the archives before they
+#   are restored.
+#
+# skip_restore_test: [boolean] default FALSE
+#   By default, this playbook tests that the content created by pulp-populate
+#   role is present and functional. You should set this to TRUE if you did not
+#   use the test data used by pulp-populate.
+#
+# test_results_dir: [absolute path on pulp host]
+#   This is the directory in which the test results will be placed if running
+#   restore tests. This is passed as an argument to
+#   'roles/pulp-restore-backup/files/test_restore.sh'
+#   This is not used if the restore tests are skipped.

--- a/ci/ansible/roles/pulp-backup/defaults/main.yaml
+++ b/ci/ansible/roles/pulp-backup/defaults/main.yaml
@@ -1,0 +1,17 @@
+---
+fetch_to_localhost: true
+remote_bkup_dir: "{{ ansible_user_dir }}/remote_backups"
+local_bkup_dir: "backups"
+files_to_backup:
+  etc_pulp:
+    src_dir: /etc/pulp
+    file: etc_pulp
+  etc_pki_pulp:
+    src_dir: /etc/pki/pulp
+    file: etc_pki_pulp
+  var_lib_pulp:
+    src_dir: /var/lib/pulp
+    file: var_lib_pulp
+db_to_bkup:
+  dir: mongodb_backup_dir
+  file: mongodb_backup

--- a/ci/ansible/roles/pulp-backup/handlers/main.yaml
+++ b/ci/ansible/roles/pulp-backup/handlers/main.yaml
@@ -1,0 +1,12 @@
+---
+
+- name: Start Pulp
+  service: "name={{ item }} state=started"
+  with_items:
+    - httpd
+    - pulp_celerybeat
+    - pulp_resource_manager
+    - pulp_streamer
+    - pulp_workers
+    - qpidd
+

--- a/ci/ansible/roles/pulp-backup/tasks/main.yaml
+++ b/ci/ansible/roles/pulp-backup/tasks/main.yaml
@@ -1,0 +1,57 @@
+# rhel6 pulp 2.11.z backup
+- name: Stop Pulp
+  service: "name={{ item }} state=stopped"
+  with_items:
+    - httpd
+    - pulp_celerybeat
+    - pulp_resource_manager
+    - pulp_streamer
+    - pulp_workers
+    - qpidd
+  notify: Start Pulp
+
+- name: Install dependencies
+  action: "{{ ansible_pkg_mgr }} name={{ item }} state=present"
+  with_items:
+    - tar
+    - bzip2
+    - bzip2-libs
+
+- name: Create backups folder
+  file: path={{ remote_bkup_dir }} state=directory
+
+- name: Create local backups folder
+  local_action: file path={{ local_bkup_dir }} state=directory
+  become: false
+  when: fetch_to_localhost
+
+- name: Dump mongodb database
+  command: "mongodump --db pulp_database --out {{ remote_bkup_dir }}/{{ db_to_bkup.dir }}"
+
+- name: Archive filesystem backups
+  command: "tar -cjf {{ remote_bkup_dir }}/{{ item.value.file }}.tar.bz2 {{ item.value.src_dir }}/"
+  with_dict: "{{ files_to_backup }}"
+
+- name: Archive database backups
+  archive:
+    path: "{{ remote_bkup_dir }}/{{ db_to_bkup.dir }}"
+    dest: "{{ remote_bkup_dir }}/{{ db_to_bkup.file }}.bz2"
+    format: bz2
+
+- name: Fetch filesystem backups
+  fetch:
+    src: "{{ remote_bkup_dir }}/{{ item.value.file }}.tar.bz2"
+    dest: "{{ local_bkup_dir }}/{{ item.value.file }}.tar.bz2"
+    flat: yes
+  with_dict: "{{ files_to_backup }}"
+
+- name: Fetch database backups
+  fetch:
+    src: "{{ remote_bkup_dir }}/{{ db_to_bkup.file }}.bz2"
+    dest: "{{ local_bkup_dir }}/{{ db_to_bkup.file }}.bz2"
+    flat: yes
+  when: fetch_to_localhost
+
+- name: Delete temp backup folder from server
+  file: path={{ remote_bkup_dir }} state=absent
+  when: fetch_to_localhost

--- a/ci/ansible/roles/pulp-migrate-tools/defaults/main.yml
+++ b/ci/ansible/roles/pulp-migrate-tools/defaults/main.yml
@@ -1,0 +1,17 @@
+# Pulp system hostname
+pulp_smash_system_hostname: "localhost"
+
+# If Pulp's API is published over HTTPS or HTTP
+pulp_smash_api_scheme: "https"
+
+# Pulp Server username
+pulp_smash_pulp_username: "admin"
+
+# Pulp Server password
+pulp_smash_pulp_password: "admin"
+
+# If SSL certificate should be verified
+pulp_smash_api_verify: "false"
+
+# AMQP broker service either qpidd or rabbitmq
+pulp_smash_amqp_broker_service: "qpidd"

--- a/ci/ansible/roles/pulp-migrate-tools/tasks/main.yaml
+++ b/ci/ansible/roles/pulp-migrate-tools/tasks/main.yaml
@@ -1,0 +1,47 @@
+---
+- name: Start Pulp
+  service: "name={{ item }} state=started"
+  with_items:
+    - httpd
+    - pulp_celerybeat
+    - pulp_resource_manager
+    - pulp_streamer
+    - pulp_workers
+    - qpidd
+
+- name: Install packages required for population task
+  action: "{{ ansible_pkg_mgr }} name={{ item }} state=present"
+  with_items:
+    - python34
+    - python34-setuptools
+    - gcc
+    - git
+
+- name: Create a directory for virtualenvs
+  file:
+    path: "{{ ansible_user_dir }}/.venvs"
+    state: directory
+
+- name: Create a virtualenv
+  command: python3 -m venv "{{ ansible_user_dir }}/.venvs/pulp-migrate"
+  args:
+    creates: "{{ ansible_user_dir }}/.venvs/pulp-migrate"
+  register: result
+
+# We fetch a zip with https://, because something asks for a password when this
+# is used: git+https://git@github.com/PulpQE/pulp-migrate.git#egg=pulp-migrate
+- name: Install pytest and pulp-migrate into the virtualenv
+  shell: >
+    source "{{ ansible_user_dir }}/.venvs/pulp-migrate/bin/activate" &&
+    pip install pytest https://github.com/PulpQE/pulp-migrate/archive/master.zip#egg=pulp-migrate
+  when: result|changed
+
+- name: Create directory for pulp smash configuration file
+  file:
+    path: "{{ ansible_user_dir }}/.config/pulp_smash"
+    state: directory
+
+- name: Create pulp smash configuration file
+  template:
+    src: settings.j2
+    dest: "{{ ansible_user_dir }}/.config/pulp_smash/settings.json"

--- a/ci/ansible/roles/pulp-migrate-tools/templates/settings.j2
+++ b/ci/ansible/roles/pulp-migrate-tools/templates/settings.j2
@@ -1,0 +1,38 @@
+{
+    "pulp": {
+        {% if pulp_smash_pulp_version|default() %}
+        "version": "{{ pulp_smash_pulp_version }}",
+        {% endif %}
+        "auth": ["{{ pulp_smash_pulp_username }}", "{{ pulp_smash_pulp_password }}"]
+    },
+    "systems": [
+        {
+            "hostname": "{{ pulp_smash_system_hostname }}",
+            "roles": {
+                "amqp broker": {
+                    "service": "{{ pulp_smash_amqp_broker_service }}"
+                },
+                "api": {
+                    "scheme": "{{ pulp_smash_api_scheme }}",
+                    {# "verify" may be either a boolean or a string path to a cert. #}
+                    {% if pulp_smash_api_verify in (true, "true", false, "false") %}
+                    "verify": {{ pulp_smash_api_verify }}
+                    {% else %}
+                    "verify": "{{ pulp_smash_api_verify }}"
+                    {% endif %}
+                },
+                "mongod": {},
+                "pulp celerybeat": {},
+                "pulp cli": {},
+                "pulp resource manager": {},
+                "pulp workers": {},
+                "shell": {
+                    {% if pulp_smash_shell_transport|default() %}
+                    "transport": "{{ pulp_smash_shell_transport }}"
+                    {% endif %}
+                },
+                "squid": {}
+            }
+        }
+    ]
+}

--- a/ci/ansible/roles/pulp-populate/defaults/main.yml
+++ b/ci/ansible/roles/pulp-populate/defaults/main.yml
@@ -1,0 +1,1 @@
+test_results_dir: "{{ ansible_user_dir }}"

--- a/ci/ansible/roles/pulp-populate/meta/main.yml
+++ b/ci/ansible/roles/pulp-populate/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: pulp-migrate-tools }

--- a/ci/ansible/roles/pulp-populate/tasks/main.yaml
+++ b/ci/ansible/roles/pulp-populate/tasks/main.yaml
@@ -1,0 +1,7 @@
+---
+- name: Populate the server
+  shell: >
+    source "{{ ansible_user_dir }}/.venvs/pulp-migrate/bin/activate" &&
+    pytest --junit-xml "{{ test_results_dir }}/populate.test.report.xml" --pyargs pulp_migrate.populate
+  ignore_errors: yes
+  # We would rather find out about errors from the xml report and not halt all execution

--- a/ci/ansible/roles/pulp-restore-backup/defaults/main.yaml
+++ b/ci/ansible/roles/pulp-restore-backup/defaults/main.yaml
@@ -1,0 +1,19 @@
+---
+remote_bkup_dir: "/root/backups"
+local_bkup_dir: "backups"
+files_to_restore:
+  etc_pulp:
+    dest_dir: /etc/pulp
+    file: etc_pulp
+    archive: etc_pulp.tar.bz2
+  etc_pki_pulp:
+    dest_dir: /etc/pki/pulp
+    file: etc_pki_pulp
+    archive: etc_pki_pulp.tar.bz2
+  var_lib_pulp:
+    dest_dir: /var/lib/pulp
+    file: var_lib_pulp
+    archive: var_lib_pulp.tar.bz2
+db_to_restore:
+  archive: mongodb_backup.bz2
+  dir: mongodb_backup_dir

--- a/ci/ansible/roles/pulp-restore-backup/handlers/main.yaml
+++ b/ci/ansible/roles/pulp-restore-backup/handlers/main.yaml
@@ -1,0 +1,11 @@
+---
+- name: Start Pulp
+  service: "name={{ item }} state=started"
+  with_items:
+    - httpd
+    - pulp_celerybeat
+    - pulp_resource_manager
+    - pulp_streamer
+    - pulp_workers
+    - qpidd
+

--- a/ci/ansible/roles/pulp-restore-backup/tasks/main.yaml
+++ b/ci/ansible/roles/pulp-restore-backup/tasks/main.yaml
@@ -1,0 +1,69 @@
+# rhel7 pulp 2.13.z restore
+- name: Ensure expected variables
+  assert:
+    that:
+      - remote_bkup_dir is defined
+      - local_bkup_dir is defined
+    msg: |
+      Location of remote backup directory and local directory for backup to be copied to
+      must be specified with varibales remote_bkup_dir and local_bkup_dir
+
+- name: Install dependencies
+  action: "{{ ansible_pkg_mgr }} name={{ item }} state=present"
+  with_items:
+    - tar
+    - bzip2
+    - bzip2-libs
+
+- name: Stop Pulp
+  service: "name={{ item }} state=stopped"
+  with_items:
+    - httpd
+    - pulp_celerybeat
+    - pulp_resource_manager
+    - pulp_streamer
+    - pulp_workers
+    - qpidd
+  notify: Start Pulp
+
+- name: Make sure backup folder exists
+  file: "path={{ remote_bkup_dir }} state=directory"
+
+- name: Copy filesystem backups to remote
+  copy:
+    src: "{{ local_bkup_dir }}/{{ item.value.archive }}"
+    dest: "{{ remote_bkup_dir }}"
+  with_dict: "{{ files_to_restore }}"
+
+- name: Unarchive filesystem backups
+  command: "tar vxjf {{ remote_bkup_dir }}/{{ item.value.archive }} --overwrite"
+  args:
+    chdir: "/"
+  with_dict: "{{ files_to_restore }}"
+
+- name: Reset SELinux labels
+  command: "restorecon -r {{ item.value.dest_dir }}"
+  with_dict: " {{ files_to_restore }}"
+
+- name: Drop pulp database
+  command: "mongo pulp_database --eval 'db.dropDatabase()'"
+
+# unarchive module fails probably because
+# it relies on the using the "--diff" option which fails when
+# unarchiving a directory full of files that don't yet exist
+# See: https://github.com/ansible/ansible-modules-core/issues/2936#issuecomment-189579092
+- name: Copy database backups to remote
+  copy:
+    src: "{{ local_bkup_dir }}/{{ db_to_restore.archive }}"
+    dest: "{{ remote_bkup_dir }}"
+
+- name: Unarchive database backups
+  command: "tar vxjf {{ remote_bkup_dir }}/{{ db_to_restore.archive }}"
+  args:
+    chdir: "{{ remote_bkup_dir }}"
+
+- name: Restore database from backup
+  command: "mongorestore {{ remote_bkup_dir }}/{{ db_to_restore.dir }}"
+
+- name: Run pulp-manage-db
+  command: "sudo -u apache pulp-manage-db"

--- a/ci/ansible/roles/pulp-test-populate/defaults/main.yml
+++ b/ci/ansible/roles/pulp-test-populate/defaults/main.yml
@@ -1,0 +1,1 @@
+test_results_dir: "{{ ansible_user_dir }}"

--- a/ci/ansible/roles/pulp-test-populate/meta/main.yml
+++ b/ci/ansible/roles/pulp-test-populate/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: pulp-migrate-tools }

--- a/ci/ansible/roles/pulp-test-populate/tasks/main.yaml
+++ b/ci/ansible/roles/pulp-test-populate/tasks/main.yaml
@@ -1,0 +1,7 @@
+---
+- name: Test that the server is populated
+  shell: >
+    source "{{ ansible_user_dir }}/.venvs/pulp-migrate/bin/activate" &&
+    pytest --junit-xml "{{ test_results_dir }}/restore.test.report.xml" --pyargs pulp_migrate.test_restore
+  ignore_errors: yes
+  # We would rather find out about errors from the xml report and not halt all execution

--- a/ci/ansible/roles/subscription-manager/tasks/main.yaml
+++ b/ci/ansible/roles/subscription-manager/tasks/main.yaml
@@ -22,6 +22,7 @@
     username: "{{ rhn_username }}"
     password: "{{ rhn_password }}"
     pool: "{{ rhn_pool }}"  # e.g. rhn_pool='^SKU Name$'
+  ignore_errors: yes
   when:
     - rhn_pool is defined
     - rhn_username is defined


### PR DESCRIPTION
Adds two playbooks and three roles.

The `pulp_backup.yaml` playbook uses existing roles to install pulp on a
host, and then uses the new roles pulp-populate and pulp-backup to
populate it with content and back it up. Optionally, the user can fetch
the backup files to the control node.

The `pulp_restore.yaml` playbook uses existing roles to install pulp on
a host and uses the new role pulp-restore-backup to restore the files
and (optionally) test whether or not the restore succeeded.

These changes should be merged before #417, because #417 depends on these changes.

There are jenkins jobs using this branch that I can link you to to demonstrate how it works.