### PR TITLE
Add jobs to backup and restore pulp

### DIFF
--- a/ci/jjb/jobs/projects.yaml
+++ b/ci/jjb/jobs/projects.yaml
@@ -63,6 +63,31 @@
         - pulp-{pulp_version}-dev-{os}
 
 - project:
+    name: pulp-restore
+    os:
+        - 'rhel7'
+    pulp_version:
+        - '2.13'
+    pulp_build:
+        - 'stable'
+    backup_version: '2.11'
+    backup_build: 'stable'
+    backup_os: 'rhel6'
+    jobs:
+        - pulp-{pulp_version}-{pulp_build}-restore-{os}
+
+- project:
+    name: pulp-backup
+    os:
+        - 'rhel6'
+    pulp_build:
+        - 'stable'
+    pulp_version:
+        - '2.11'
+    jobs:
+        - pulp-{pulp_version}-{pulp_build}-backup-{os}
+
+- project:
     name: pulp-fixtures-publisher
     jobs:
         - pulp-fixtures-publisher

--- a/ci/jjb/jobs/pulp-backup.yaml
+++ b/ci/jjb/jobs/pulp-backup.yaml
@@ -1,0 +1,50 @@
+- job-template:
+    name: 'pulp-{pulp_version}-{pulp_build}-backup-{os}'
+    node: '{os}-np'
+    properties:
+        - qe-ownership
+        # don't want to build up too many artifacts because they are of
+        # some appreciable size
+        - build-discarder:
+            days-to-keep: 7
+            num-to-keep: 7
+            artifact-days-to-keep: 7
+            artifact-num-to-keep: 3
+    scm:
+        - pulp-packaging-github
+    wrappers:
+        - config-file-provider:
+            files:
+                - file-id: rhn_credentials
+                  variable: RHN_CREDENTIALS
+        - inject:
+            properties-content: |
+                OS={os}
+                PULP_BUILD={pulp_build}
+                PULP_VERSION={pulp_version}
+    triggers:
+        - timed: '@midnight'
+    builders:
+        - shell:
+            !include-raw-escape:
+                - 'ssh-setup.sh'
+        - shell:
+            !include-raw-escape:
+                - 'ansible-setup.sh'
+                - 'pulp-backup.sh'
+        - capture-logs
+    publishers:
+      - postbuildscript:
+          script-only-if-succeeded: False
+          script-only-if-failed: False
+          builders:
+            - shell: |
+                if [[ "${{OS}}" =~ "rhel" ]]; then
+                    sudo subscription-manager unregister
+                fi
+      - archive:
+          artifacts: '*.bz2'
+      - junit:
+          results: "*.xml"
+      - email-notify-owners
+      - mark-node-offline

--- a/ci/jjb/jobs/pulp-restore.yaml
+++ b/ci/jjb/jobs/pulp-restore.yaml
@@ -1,0 +1,48 @@
+- job-template:
+    name: 'pulp-{pulp_version}-{pulp_build}-restore-{os}'
+    node: '{os}-np'
+    properties:
+        - qe-ownership
+    scm:
+        - pulp-packaging-github
+    wrappers:
+        - config-file-provider:
+            files:
+                - file-id: rhn_credentials
+                  variable: RHN_CREDENTIALS
+        - inject:
+            properties-content: |
+                OS={os}
+                PULP_BUILD={pulp_build}
+                PULP_VERSION={pulp_version}
+    triggers:
+        - reverse:
+            jobs: 'pulp-{backup_version}-{backup_build}-backup-{backup_os}'
+            result: 'success'
+    builders:
+        - copyartifact:
+            project: 'pulp-{backup_version}-{backup_build}-backup-{backup_os}'
+            which-build: last-successful
+            filter: "*.bz2"
+            flatten: true
+        - shell:
+            !include-raw-escape:
+                - 'ssh-setup.sh'
+        - shell:
+            !include-raw-escape:
+                - 'ansible-setup.sh'
+                - 'pulp-restore.sh'
+        - capture-logs
+    publishers:
+        - postbuildscript:
+            script-only-if-succeeded: False
+            script-only-if-failed: False
+            builders:
+              - shell: |
+                  if [[ "${{OS}}" =~ "rhel" ]]; then
+                      sudo subscription-manager unregister
+                  fi
+        - junit:
+            results: "*.xml"
+        - email-notify-owners
+        - mark-node-offline

--- a/ci/jjb/scripts/ansible-setup.sh
+++ b/ci/jjb/scripts/ansible-setup.sh
@@ -1,0 +1,3 @@
+sudo yum -y install ansible attr git libselinux-python
+source "${RHN_CREDENTIALS}"
+export ANSIBLE_CONFIG="${PWD}/ci/ansible/ansible.cfg"

--- a/ci/jjb/scripts/pulp-backup.sh
+++ b/ci/jjb/scripts/pulp-backup.sh
@@ -1,0 +1,10 @@
+ansible-playbook --connection local -i "localhost," ci/ansible/pulp_backup.yaml \
+    -e "pulp_build=${PULP_BUILD}" \
+    -e "pulp_version=${PULP_VERSION}" \
+    -e "rhn_password=${RHN_PASSWORD}" \
+    -e "rhn_pool=${RHN_POOL}" \
+    -e "rhn_username=${RHN_USERNAME}" \
+    -e "local_bkup_dir=${PWD}/local_backups" \
+    -e "remote_bkup_dir=${PWD}" \
+    -e "fetch_to_localhost=false" \
+    -e "test_results_dir=${PWD}"

--- a/ci/jjb/scripts/pulp-restore.sh
+++ b/ci/jjb/scripts/pulp-restore.sh
@@ -1,0 +1,9 @@
+ansible-playbook --connection local -i "localhost," ci/ansible/pulp_restore.yaml \
+    -e "pulp_build=${PULP_BUILD}" \
+    -e "pulp_version=${PULP_VERSION}" \
+    -e "rhn_password=${RHN_PASSWORD}" \
+    -e "rhn_pool=${RHN_POOL}" \
+    -e "rhn_username=${RHN_USERNAME}" \
+    -e "local_bkup_dir=${PWD}" \
+    -e "remote_bkup_dir=${PWD}/remote_backups" \
+    -e "test_results_dir=${PWD}"


### PR DESCRIPTION
Add pulp-restore and pulp-backup job templates that generate jobs to
test that pulp can be backed up and the data can be migrated to a
different version and OS.

These changes don't make sense to merge until #416 is merged.

I can link you to jobs that use the #416 branch upon request!