### PR TITLE
Reformat Ansible play

### DIFF
--- a/ci/ansible/roles/pulp-certs/tasks/main.yml
+++ b/ci/ansible/roles/pulp-certs/tasks/main.yml
@@ -5,27 +5,32 @@
     name: openssl-perl
     state: present
   when:
-    - ansible_distribution == "Fedora"
+    - ansible_distribution == 'Fedora'
     - ansible_distribution_major_version|int == 26
 
 - name: Create CA to sign all certificates
   command: >
     /usr/bin/openssl req -x509 -newkey rsa:2048 -keyout private/cakey.pem -nodes -days 3650
-     -out cacert.pem -subj '/C=US/ST=North Carolina/L=Raleigh/O=Pulp/OU=Development/CN=PulpCA'
+    -out cacert.pem
+    -subj '/C=US/ST=North Carolina/L=Raleigh/O=Pulp/OU=Development/CN=PulpCA'
   args:
     chdir: /etc/pki/CA/
     creates: cacert.pem
 
 - name: Create CA index.txt
-  file: path=/etc/pki/CA/index.txt state=touch owner=root group=root mode=0644
+  file:
+    path: /etc/pki/CA/index.txt
+    state: touch
+    owner: root
+    group: root
+    mode: 0644
 
 - name: Enable dynamic CA trust store
   shell: update-ca-trust enable
-  when: ansible_distribution == "RedHat" and ansible_distribution_major_version|int == 6
+  when: ansible_distribution == 'RedHat' and ansible_distribution_major_version|int == 6
 
 - name: Add CA to trust store
-  shell: >
-    cp /etc/pki/CA/cacert.pem /etc/pki/ca-trust/source/anchors/cacert.pem
+  shell: cp /etc/pki/CA/cacert.pem /etc/pki/ca-trust/source/anchors/cacert.pem
   args:
     creates: /etc/pki/ca-trust/source/anchors/cacert.pem
 
@@ -33,14 +38,15 @@
   shell: update-ca-trust
 
 - name: Configure openssl subjectAltName
-  lineinfile: dest=/etc/pki/tls/openssl.cnf
-              insertafter="^\[ usr_cert \]"
-              line="subjectAltName=DNS:{{ ansible_fqdn }},DNS:{{ ansible_nodename }},DNS:{{ ansible_hostname }}"
+  lineinfile:
+    dest: /etc/pki/tls/openssl.cnf
+    insertafter: '^\[ usr_cert \]'
+    line: 'subjectAltName=DNS:{{ ansible_fqdn }},DNS:{{ ansible_nodename }},DNS:{{ ansible_hostname }}'
 
 - name: Create Apache certificate request
   command: >
     /usr/bin/openssl req -newkey rsa:2048 -keyout private/apachekey.pem -nodes -days 365
-    -out certs/apachereq.pem \
+    -out certs/apachereq.pem
     -subj '/C=US/ST=North Carolina/L=Raleigh/O=Pulp/OU=Development/CN={{ ansible_hostname }}'
   args:
     chdir: /etc/pki/tls/
@@ -57,14 +63,14 @@
 # In the distant future when Ansible sets everything up, this should notify httpd
 - name: Configure Apache TLS certificate
   lineinfile:
-      backrefs: yes
-      dest: /etc/httpd/conf.d/ssl.conf
-      regexp: "^SSLCertificateFile "
-      line: "SSLCertificateFile /etc/pki/tls/certs/apachecert.pem"
+    backrefs: yes
+    dest: /etc/httpd/conf.d/ssl.conf
+    regexp: '^SSLCertificateFile '
+    line: 'SSLCertificateFile /etc/pki/tls/certs/apachecert.pem'
 
 - name: Configure Apache TLS private key
   lineinfile:
-      backrefs: yes
-      dest: /etc/httpd/conf.d/ssl.conf
-      regexp: "^SSLCertificateKeyFile "
-      line: "SSLCertificateKeyFile /etc/pki/tls/private/apachekey.pem"
+    backrefs: yes
+    dest: /etc/httpd/conf.d/ssl.conf
+    regexp: '^SSLCertificateKeyFile '
+    line: 'SSLCertificateKeyFile /etc/pki/tls/private/apachekey.pem'


### PR DESCRIPTION
Ensure the following rules are followed:

* Use two spaces for each level of indentation.
* Use YAML syntax when passing arguments to Ansible modules, instead of
  Ansible's inline syntax.
* Use single quotes instead of double quotes where possible. (Yaml
  requires escaping backslashes in double quotes but not in single
  quotes.)
* Don't use back-slashes to wrap lines unless necessary.