### PR TITLE
Unregister jenkins nodes as a post-build action

### DIFF
--- a/ci/jjb/jobs/pulp-dev.yaml
+++ b/ci/jjb/jobs/pulp-dev.yaml
@@ -67,10 +67,6 @@
                     -e pulp_coverage_report_xml=true
                 cp /tmp/report.xml coverage.xml
             fi
-            if [[ "${{OS}}" =~ "rhel" ]]; then
-                sudo subscription-manager unregister
-                sudo subscription-manager clean
-            fi
         # TODO: Uncomment and update the configuration when sonar is ready to
         # be used
         # - conditional-step:
@@ -82,6 +78,14 @@
         #             sonar-name: 'Sonar Test Server'
         - capture-logs
     publishers:
+        - postbuildscript:
+            script-only-if-succeeded: False
+            script-only-if-failed: False
+            builders:
+              - shell: |
+                  if [[ "${{OS}}" =~ "rhel" ]]; then
+                      sudo subscription-manager unregister
+                  fi
         - junit:
             results: junit-report.xml
         - cobertura:

--- a/ci/jjb/jobs/pulp-upgrade.yaml
+++ b/ci/jjb/jobs/pulp-upgrade.yaml
@@ -82,13 +82,16 @@
             which-build: specific-build
             build-number: ${{TRIGGERED_BUILD_NUMBER_PULP_SMASH_RUNNER}}
             flatten: true
-        - shell: |
-            if [[ "${{OS}}" =~ "rhel" ]]; then
-                sudo subscription-manager unregister
-                sudo subscription-manager clean
-            fi
         - capture-logs
     publishers:
+      - postbuildscript:
+          script-only-if-succeeded: False
+          script-only-if-failed: False
+          builders:
+            - shell: |
+                if [[ "${{OS}}" =~ "rhel" ]]; then
+                    sudo subscription-manager unregister
+                fi
       - archive:
           artifacts: "*.tar.gz"
           allow-empty: true


### PR DESCRIPTION
Previously, if a build on a RHEL system failed after registering, but
before unregistering, the only recouse left to release the entitlements
the system used up would be through the customer portal.

(John from candlepin QE pointed this out.)

This PR adds the unregister step as a post-build action that happens no
matter if the build fails or succeeds.