### PR TITLE
Adding 2.14 to pulp-version

### DIFF
--- a/ci/jjb/jobs/projects.yaml
+++ b/ci/jjb/jobs/projects.yaml
@@ -111,6 +111,7 @@
         - 2.11-stable
         - 2.12-stable
         - 2.13-stable
+        - 2.14-stable
     upgrade_pulp_version:
         - 2.11-beta
         - 2.12-beta


### PR DESCRIPTION
Adding 2.14 to pulp-version for upgrading from 2.14-stable to 2.14.latest-beta.