### PR TITLE
Add JWT dependency to docs builders

### DIFF
--- a/ci/jjb/jobs/docs.yaml
+++ b/ci/jjb/jobs/docs.yaml
@@ -51,7 +51,7 @@
             # create a virtualenv in which to install packages needed to build docs
             virtualenv -p /usr/bin/python3 --system-site-packages ~/docs_ve
             source ~/docs_ve/bin/activate
-            pip3 install sphinx git+https://github.com/snide/sphinx_rtd_theme.git@abfa98539a2bfc44198a9ca8c2f16efe84cc4d26 pyyaml virtualenv
+            pip3 install djangorestframework-jwt sphinx git+https://github.com/snide/sphinx_rtd_theme.git@abfa98539a2bfc44198a9ca8c2f16efe84cc4d26 pyyaml virtualenv
 
             # create server.yaml config file
             sudo mkdir -p /etc/pulp

--- a/ci/jjb/jobs/pr-docs.yaml
+++ b/ci/jjb/jobs/pr-docs.yaml
@@ -73,7 +73,7 @@
             # create a virtualenv in which to install packages needed to build docs
             virtualenv -p /usr/bin/python3 --system-site-packages ~/docs_ve
             source ~/docs_ve/bin/activate
-            pip3 install sphinx git+https://github.com/snide/sphinx_rtd_theme.git@abfa98539a2bfc44198a9ca8c2f16efe84cc4d26 pyyaml virtualenv
+            pip3 install djangorestframework-jwt sphinx git+https://github.com/snide/sphinx_rtd_theme.git@abfa98539a2bfc44198a9ca8c2f16efe84cc4d26 pyyaml virtualenv
 
             # create server.yaml config file
             sudo mkdir -p /etc/pulp


### PR DESCRIPTION
Pulp3 will depend on a DRF plugin called djangorestframework-jwt. When
building the docs it needs to be able to import this dependency. This
will update both the PR and regular docs builders.

re #2359
https://pulp.plan.io/issues/2359