### PR TITLE
Add pulp dependencies to docs builders 

### DIFF
--- a/ci/jjb/jobs/docs.yaml
+++ b/ci/jjb/jobs/docs.yaml
@@ -51,7 +51,7 @@
             # create a virtualenv in which to install packages needed to build docs
             virtualenv -p /usr/bin/python3 --system-site-packages ~/docs_ve
             source ~/docs_ve/bin/activate
-            pip3 install djangorestframework-jwt sphinx git+https://github.com/snide/sphinx_rtd_theme.git@abfa98539a2bfc44198a9ca8c2f16efe84cc4d26 pyyaml virtualenv
+            pip3 install celery django django-filter djangorestframework djangorestframework-jwt drf-nested-routers psycopg2 sphinx git+https://github.com/snide/sphinx_rtd_theme.git@abfa98539a2bfc44198a9ca8c2f16efe84cc4d26 pyyaml virtualenv
 
             # create server.yaml config file
             sudo mkdir -p /etc/pulp

--- a/ci/jjb/jobs/pr-docs.yaml
+++ b/ci/jjb/jobs/pr-docs.yaml
@@ -73,7 +73,7 @@
             # create a virtualenv in which to install packages needed to build docs
             virtualenv -p /usr/bin/python3 --system-site-packages ~/docs_ve
             source ~/docs_ve/bin/activate
-            pip3 install djangorestframework-jwt sphinx git+https://github.com/snide/sphinx_rtd_theme.git@abfa98539a2bfc44198a9ca8c2f16efe84cc4d26 pyyaml virtualenv
+            pip3 install celery django django-filter djangorestframework djangorestframework-jwt drf-nested-routers psycopg2 sphinx git+https://github.com/snide/sphinx_rtd_theme.git@abfa98539a2bfc44198a9ca8c2f16efe84cc4d26 pyyaml virtualenv
 
             # create server.yaml config file
             sudo mkdir -p /etc/pulp
@@ -164,7 +164,7 @@
             # create a virtualenv in which to install packages needed to build docs
             virtualenv -p /usr/bin/python3 --system-site-packages ~/docs_ve
             source ~/docs_ve/bin/activate
-            pip3 install sphinx git+https://github.com/snide/sphinx_rtd_theme.git@abfa98539a2bfc44198a9ca8c2f16efe84cc4d26 pyyaml virtualenv
+            pip3 install celery django django-filter djangorestframework djangorestframework-jwt drf-nested-routers psycopg2 sphinx git+https://github.com/snide/sphinx_rtd_theme.git@abfa98539a2bfc44198a9ca8c2f16efe84cc4d26 pyyaml virtualenv
 
             cd $WORKSPACE/plugin/docs
 


### PR DESCRIPTION
When building the docs we need a full pulp3 environment for the docs to
build correctly. This is due to the importing that occurs during docs
building.

re #2359
https://pulp.plan.io/issues/2359