### PR TITLE
Add Jenkins job to install and smash Pulp 3

### DIFF
--- a/ci/jjb/jobs/projects.yaml
+++ b/ci/jjb/jobs/projects.yaml
@@ -70,6 +70,14 @@
         - pulp-{pulp_version}-dev-{os}
 
 - project:
+    name: pulp-3-dev
+    os:
+        - f25
+        - f26
+    jobs:
+        - pulp-3-dev-{os}
+
+- project:
     name: pulp-restore
     os:
         - 'rhel7'

--- a/ci/jjb/jobs/pulp-3-dev.yaml
+++ b/ci/jjb/jobs/pulp-3-dev.yaml
@@ -1,0 +1,49 @@
+# Install Pulp 3 on a host with Ansible, and smash it.
+#
+# This code assumes that Pulp and Pulp Smash are to be installed on localhost.
+- job-template:
+    name: pulp-3-dev-{os}
+    node: '{os}-np'
+    description: |
+      <p>Install Pulp 3 on a host with Ansible, and smash it.</p>
+      <p>
+        The installation procedure assumes that Pulp and Pulp Smash should be
+        installed on localhost. As a result, actions like SSH configuration are
+        skipped.
+      </p>
+      <p>
+        At this time, the "test" consists of running a simple command to verify
+        that Pulp Smash is correctly installed.
+      </p>
+    properties:
+      - qe-ownership
+    scm:
+      - git:
+          url: https://github.com/pulp/devel.git
+          branches:
+            - '3.0-dev'
+          skip-tag: true
+    builders:
+      # Install Pulp 3.
+      - shell: |
+          sudo dnf -y install ansible python3
+          # See the scm: block above.
+          cd ansible
+          ansible-galaxy install -r requirements.yml -p roles
+          # Pulp 3 can't deal with SELinux.
+          ansible all \
+            --inventory localhost, \
+            --connection local \
+            --become \
+            -m selinux \
+            -a state=disabled
+          ansible-playbook deploy-pulp3.yml \
+            --inventory localhost, \
+            --connection local
+      # Install Pulp Smash.
+      - shell:
+          !include-raw-escape:
+            - pulp-smash-setup.sh
+    publishers:
+      - email-notify-owners
+      - mark-node-offline

--- a/ci/jjb/scripts/pulp-smash-setup.sh
+++ b/ci/jjb/scripts/pulp-smash-setup.sh
@@ -1,0 +1,33 @@
+mkdir -p ~/.virtualenvs/pulp-smash/
+python3 -m venv ~/.virtualenvs/pulp-smash
+source ~/.virtualenvs/pulp-smash/bin/activate
+pip install --upgrade pip
+pip install git+https://github.com/PulpQE/pulp-smash.git#egg=pulp-smash
+mkdir -p ~/.config/pulp_smash
+cat >~/.config/pulp_smash/settings.json <<EOF
+{
+    "pulp": {
+        "auth": ["admin", "admin"],
+        "version": "3"
+    },
+    "systems": [
+        {
+            "hostname": "$(hostname --long)",
+            "roles": {
+                "amqp broker": {"service": "rabbitmq"},
+                "api": {"scheme": "http"},
+                "mongod": {},
+                "pulp celerybeat": {},
+                "pulp cli": {},
+                "pulp resource manager": {},
+                "pulp workers": {},
+                "shell": {},
+                "squid": {}
+            }
+        }
+    ]
+}
+EOF
+pulp-smash settings path
+pulp-smash settings show
+pulp-smash settings validate


### PR DESCRIPTION
The new job is called `pulp-3-dev-{os}`. It can be run against Fedora 25
and 26. It can't be run against RHEL, as neither it nor the Ansible
playbooks it calls have logic for working with subscription manager.