### PR TITLE
Update documentation for pulp-installer job

### DIFF
--- a/ci/jjb/jobs/pulp-installer.yaml
+++ b/ci/jjb/jobs/pulp-installer.yaml
@@ -5,18 +5,32 @@
     concurrent: true
     node: 'fedora-np'
     description: |
-        <p>Job that installs Pulp on the machine identified by the job
-        parameter.</p>
-        <p>In order to use this job, make sure that the target machine have the
-        following key on the <code>.ssh/authorized_keys</code>.</p>
+        <p>
+          Install Pulp on the host identified by the job parameter
+          <code>HOSTNAME</code>.
+        </p>
+        <p>
+          This job requires two hosts: one for use as an Ansible control host,
+          and one on which to install Pulp. Jenkins is responsible for providing
+          the control host, and you are responsible for providing the Pulp host.
+          When this job is executed, Jenkins will configure the control host, by
+          doing things like installing Ansible and configuring SSH keys. Then,
+          the control host will reach out and install Pulp onto the host
+          identified by <code>HOSTNAME</code>.
+        </p>
+        <p>
+          Ensure the following is in <code>~/.ssh/authorized_keys</code> on the
+          Pulp host:
+        </p>
         <pre>
-        ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC6DJ8fmd61DWPCMiOEuy96ajI7rL3rWu7C9NQhE9a4SfyaiBcghREHJNCz9LGJ57jtOmNV0+UEDhyvTckZI2YQeDqGCP/xO9B+5gQNlyGZ9gSmFz+68NhYQ0vRekikpb9jNdy6ZZbfZDLp1w7dxqDIKfoyu7QO3Qr3E/9CpiucQif2p+oQOVOCdKEjvGYNkYQks0jVTYNRscgmcezpfLKhqWzAre5+JaMB0kRD5Nqadm2uXKZ4cNYStrpZ4xUrnMvAqjormxW2VJNx+0716Wc2Byhg8Nva+bsOkxp/GewBWHfNPtzQGMsL7oYZPtOd/LrmyYeu/M5Uz7/6QCv4N90P pulp
+          ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC6DJ8fmd61DWPCMiOEuy96ajI7rL3rWu7C9NQhE9a4SfyaiBcghREHJNCz9LGJ57jtOmNV0+UEDhyvTckZI2YQeDqGCP/xO9B+5gQNlyGZ9gSmFz+68NhYQ0vRekikpb9jNdy6ZZbfZDLp1w7dxqDIKfoyu7QO3Qr3E/9CpiucQif2p+oQOVOCdKEjvGYNkYQks0jVTYNRscgmcezpfLKhqWzAre5+JaMB0kRD5Nqadm2uXKZ4cNYStrpZ4xUrnMvAqjormxW2VJNx+0716Wc2Byhg8Nva+bsOkxp/GewBWHfNPtzQGMsL7oYZPtOd/LrmyYeu/M5Uz7/6QCv4N90P pulp
         </pre>
-        <p>In addition to the key, make sure the target machine have the
-        Ansible
-        <a href="http://docs.ansible.com/ansible/intro_installation.html#managed-node-requirements">
-        Managed Node Requirements</a> in place. Would be required to install
-        some other packages like <code>dnf-python</code>.</p>
+        <p>
+          In addition, ensure the Pulp host satisfies the <a
+          href="http://docs.ansible.com/ansible/latest/intro_installation.html#managed-node-requirements">managed
+          node requirements</a>. (It may also be necessary to install some other
+          packages like <code>dnf-python</code>.)
+        </p>
     parameters:
         - choice:
             name: PULP_VERSION


### PR DESCRIPTION
Expand the description of the pulp-installer job. Ensure that readers
understand that when this job executes, *two* hosts are required.