### PR TITLE
Drop reference to unavailable private key

### DIFF
--- a/ci/jjb/jobs/pulp-installer.yaml
+++ b/ci/jjb/jobs/pulp-installer.yaml
@@ -57,7 +57,7 @@
             echo "${HOSTNAME} ansible_user=${USER}" > hosts
             source "${RHN_CREDENTIALS}"
             export ANSIBLE_CONFIG="${PWD}/ci/ansible/ansible.cfg"
-            ansible-playbook --private-key pulp_server_key -i hosts \
+            ansible-playbook -i hosts \
                 ci/ansible/pulp_server.yaml \
                 -e "pulp_build=${PULP_BUILD}" \
                 -e "pulp_version=${PULP_VERSION}" \


### PR DESCRIPTION
The pulp-installer job installs Pulp on an arbitrary host, such as a
beaker host. This job reaches out and logs in to the arbitrary host with
SSH, where authentication is handled with public/private keys. The
private key needed for logging in to the arbitrary host is provided by
ssh-agent, and ssh-agent is given this key by the
`jenkins-ssh-credentials` macro.

For some reason, the pulp-installer job also references an on-disk
private key. This reference isn't necessary, as ssh-agent already has
the needed private key. Also, this private key doesn't exist on disk.
And referencing this private key can give readers the wrong idea.

If the OpenSSH client tries an authentication method and it doesn't
work, then it'll try moving on to the next available authentication
method. This is probably why the spurious reference to a non-existent
private key didn't break anything.