### PR TITLE
Run the development Pulp 3 webserver for testing

### DIFF
--- a/ci/jjb/jobs/pulp-3-dev.yaml
+++ b/ci/jjb/jobs/pulp-3-dev.yaml
@@ -40,10 +40,21 @@
           ansible-playbook deploy-pulp3.yml \
             --inventory localhost, \
             --connection local
+      # Start Pulp 3.
+      - shell: |
+          ansible all \
+              --inventory localhost, \
+              --connection local \
+              --become \
+              --become-user pulp \
+              -m shell \
+              -a 'source ~/pulpvenv/bin/activate && pulp-manager runserver 0.0.0.0:8000 &'
       # Install Pulp Smash.
       - shell:
           !include-raw-escape:
             - pulp-smash-setup.sh
+      # Perform a sanity check against Pulp 3.
+      - shell: curl http://localhost:8000/api/v3/
     publishers:
       - email-notify-owners
       - mark-node-offline


### PR DESCRIPTION
Make the `pulp-3-dev-{os}` jobs run the development webserver after Pulp
3 has been installed, so that it can be smashed. Do so by simply
executing `pulp-manager runserver …` as the "pulp" user. This is a hacky
and awful solution, because among other things, it makes process
management a pain. Stopping the dev webserver requires manually hunting
down and killing processes. Restarting the dev webserver is worse.

However, this is intended to be a temporary solution that's only in
place until the devs figure out how Pulp 3 is supposed to run. When a
solution that integrates with Apache/Nginx/LightTPD/etc is devised, this
can be dropped.

See: https://pulp.plan.io/issues/3078

closes #3078