### PR TITLE
Make pulp-3-dev-{os} jobs smash Pulp 3

### DIFF
--- a/ci/jjb/jobs/pulp-3-dev.yaml
+++ b/ci/jjb/jobs/pulp-3-dev.yaml
@@ -11,10 +11,6 @@
         installed on localhost. As a result, actions like SSH configuration are
         skipped.
       </p>
-      <p>
-        At this time, the "test" consists of running a simple command to verify
-        that Pulp Smash is correctly installed.
-      </p>
     properties:
       - qe-ownership
     scm:
@@ -24,7 +20,7 @@
             - '3.0-dev'
           skip-tag: true
     builders:
-      # Install Pulp 3.
+      # Install and start Pulp 3.
       - shell: |
           sudo dnf -y install ansible python3
           # See the scm: block above.
@@ -40,8 +36,6 @@
           ansible-playbook deploy-pulp3.yml \
             --inventory localhost, \
             --connection local
-      # Start Pulp 3.
-      - shell: |
           ansible all \
               --inventory localhost, \
               --connection local \
@@ -49,12 +43,23 @@
               --become-user pulp \
               -m shell \
               -a 'source ~/pulpvenv/bin/activate && pulp-manager runserver 0.0.0.0:8000 &'
-      # Install Pulp Smash.
+      # Install and run Pulp Smash.
       - shell:
           !include-raw-escape:
-            - pulp-smash-setup.sh
-      # Perform a sanity check against Pulp 3.
-      - shell: curl http://localhost:8000/api/v3/
+              - pulp-3-dev-smasher.sh
     publishers:
-      - email-notify-owners
-      - mark-node-offline
+        - postbuildscript:
+            script-only-if-succeeded: False
+            script-only-if-failed: False
+            builders:
+              - shell: |
+                  if [[ "${{OS}}" =~ "rhel" ]]; then
+                      sudo subscription-manager unregister
+                  fi
+        - junit:
+            results: 'junit-report.xml'
+        - archive:
+            artifacts: "*.tar.gz"
+            allow-empty: true
+        - email-notify-owners
+        - mark-node-offline

--- a/ci/jjb/scripts/pulp-3-dev-smasher.sh
+++ b/ci/jjb/scripts/pulp-3-dev-smasher.sh
@@ -31,3 +31,7 @@ EOF
 pulp-smash settings path
 pulp-smash settings show
 pulp-smash settings validate
+# Use pytest instead of unittest for XML reports. :-(
+pip install pytest
+py.test -v --color=yes --junit-xml=junit-report.xml --pyargs pulp_smash.tests
+test -f junit-report.xml


### PR DESCRIPTION
Of note is that the pulp-smash-runner job is not being called. Instead,
a few extra shell commands are being executed.

This approach definitely has some downsides. Among other things, the
existing pulp-smash-runner job is highly configurable, where a user can
set options such as the broker used by the Pulp installation under test.
(e.g. qpid or rabbitmq) However, the job is also very complicated,
making calls to it much harder to accomplish. And the job performs some
tasks that are specific to Pulp 2, such as working with Pulp 2's SSL
certificates.

In this case, it seems better to have a good job now rather than a
perfect job later. This is doubly true if Jenkins 2 will soon be
available, which will make things like pipelines available.